### PR TITLE
Score secret signals and parse workflow policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ This project follows a simple chronological changelog. It is a learning reposito
   workflow files.
 - Rejected repository symlinks instead of silently omitting them from security
   checks, and normalized binary-extension handling across letter case.
+- Split secret and workflow classifiers into focused Rust modules, then replaced
+  broad substring matching with scored key-aware assignment parsing, provider
+  token signatures, placeholder suppression, and an average-precision floor.
+- Allowed documented environment-template variants while blocking common root
+  credential stores and password-manager databases.
+- Made workflow permission checks context-aware and required Docker actions to
+  use immutable SHA-256 digests.
 - Reconciled the roadmap with completed issue and pull request practice.
 - Promoted the Rust-native repository doctor in the README with current checks and sample passing output.
 

--- a/src/bin/check_repo.rs
+++ b/src/bin/check_repo.rs
@@ -3,11 +3,18 @@
 
 #![forbid(unsafe_code)]
 
+#[path = "check_repo/secrets.rs"]
+mod secrets;
+#[path = "check_repo/workflows.rs"]
+mod workflows;
+
+use secrets::check_secret_content;
 use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use workflows::check_workflow_content;
 
 const REQUIRED_FILES: &[&str] = &[
     "README.md",
@@ -16,6 +23,8 @@ const REQUIRED_FILES: &[&str] = &[
     "Cargo.lock",
     "src/main.rs",
     "src/bin/check_repo.rs",
+    "src/bin/check_repo/secrets.rs",
+    "src/bin/check_repo/workflows.rs",
     "scripts/doctor.sh",
     "docs/PROJECT_STRUCTURE.md",
     "docs/LOCAL_SETUP.md",
@@ -61,7 +70,25 @@ const SOURCE_REFERENCES: &[(&str, &[&str])] = &[
     ),
     (
         "src/bin/check_repo.rs",
-        &["#![forbid(unsafe_code)]", "fn check_workflow_content"],
+        &[
+            "#![forbid(unsafe_code)]",
+            "check_repo/secrets.rs",
+            "check_repo/workflows.rs",
+        ],
+    ),
+    (
+        "src/bin/check_repo/secrets.rs",
+        &[
+            "pub(crate) fn check_secret_content",
+            "fn secret_assignment_score",
+        ],
+    ),
+    (
+        "src/bin/check_repo/workflows.rs",
+        &[
+            "pub(crate) fn check_workflow_content",
+            "fn is_pinned_docker_reference",
+        ],
     ),
 ];
 
@@ -81,7 +108,12 @@ const SKIPPED_DIRS: &[&str] = &[
     "worktrees",
 ];
 
-const BINARY_SUFFIXES: &[&str] = &["gif", "ico", "jpeg", "jpg", "pdf", "png", "webp"];
+const BINARY_SUFFIXES: &[&str] = &[
+    "7z", "a", "avi", "bmp", "class", "dmg", "doc", "docx", "dylib", "eot", "exe", "flac", "gif",
+    "gz", "ico", "jar", "jpeg", "jpg", "m4a", "mov", "mp3", "mp4", "o", "otf", "pdf", "png",
+    "ppt", "pptx", "so", "tar", "tiff", "ttf", "wav", "webm", "webp", "woff", "woff2", "xls",
+    "xlsx", "zip",
+];
 
 const BLOCKED_FILENAMES: &[&str] = &[
     ".env",
@@ -97,10 +129,21 @@ const BLOCKED_FILENAMES: &[&str] = &[
     "service-account.json",
 ];
 
-const BLOCKED_SECRET_SUFFIXES: &[&str] = &[".jks", ".key", ".keystore", ".p12", ".pfx"];
+const BLOCKED_SECRET_SUFFIXES: &[&str] = &[
+    ".jks",
+    ".key",
+    ".kdbx",
+    ".keystore",
+    ".p12",
+    ".pfx",
+];
 
-const PRIVATE_KEY_PREFIX: &str = "-----BEGIN ";
-const PRIVATE_KEY_WORDS: [&str; 2] = ["PRIVATE ", "KEY-----"];
+const BLOCKED_SENSITIVE_PATHS: &[&str] = &[
+    ".aws/credentials",
+    ".config/gcloud/application_default_credentials.json",
+    ".docker/config.json",
+    ".kube/config",
+];
 
 fn main() -> ExitCode {
     let root = match env::current_dir() {
@@ -172,6 +215,10 @@ fn check_repository_files(root: &Path, files: &[PathBuf], failures: &mut Vec<Str
 
         check_evidence_artifact(&relative_path, failures);
 
+        if is_blocked_sensitive_path(&relative_path) {
+            failures.push(format!("{relative_path} is a blocked sensitive path"));
+        }
+
         if let Some(file_name) = file_path.file_name().and_then(|name| name.to_str()) {
             if is_blocked_filename(file_name) {
                 failures.push(format!("{relative_path} is a blocked sensitive filename"));
@@ -208,77 +255,6 @@ fn check_evidence_artifact(relative_path: &str, failures: &mut Vec<String>) {
         || lower_path.contains("nonredacted")
     {
         failures.push(format!("{relative_path} must be explicitly redacted"));
-    }
-}
-
-fn check_secret_content(relative_path: &str, content: &str, failures: &mut Vec<String>) {
-    let private_key_suffix = PRIVATE_KEY_WORDS.concat();
-    if content.contains(PRIVATE_KEY_PREFIX) && content.contains(&private_key_suffix) {
-        failures.push(format!(
-            "{relative_path} appears to contain private key block"
-        ));
-    }
-
-    if contains_prefixed_token(content, &["ghp_", "gho_", "ghu_", "ghs_", "ghr_"], 30) {
-        failures.push(format!("{relative_path} appears to contain GitHub token"));
-    }
-
-    if contains_prefixed_token(content, &["github_pat_"], 20) {
-        failures.push(format!(
-            "{relative_path} appears to contain GitHub fine-grained token"
-        ));
-    }
-
-    if contains_aws_access_key(content) {
-        failures.push(format!(
-            "{relative_path} appears to contain AWS access key id"
-        ));
-    }
-
-    if has_generic_secret_assignment(content) {
-        failures.push(format!(
-            "{relative_path} appears to contain generic secret assignment"
-        ));
-    }
-}
-
-fn check_workflow_content(relative_path: &str, content: &str, failures: &mut Vec<String>) {
-    if content.contains("write-all") {
-        failures.push(format!(
-            "{relative_path} must not use write-all permissions"
-        ));
-    }
-
-    for (line_number, line) in content.lines().enumerate() {
-        let trimmed_line = line.trim();
-        if trimmed_line == "contents: write" {
-            failures.push(format!("{relative_path} must not grant contents: write"));
-        }
-
-        let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
-        let Some(action_ref) = step_line.strip_prefix("uses:") else {
-            continue;
-        };
-
-        let action_ref = action_ref.split_whitespace().next().unwrap_or("");
-        if action_ref.starts_with("./") || action_ref.starts_with("docker://") {
-            continue;
-        }
-
-        let Some((_, ref_name)) = action_ref.rsplit_once('@') else {
-            failures.push(format!(
-                "{relative_path}:{} action is unpinned",
-                line_number + 1
-            ));
-            continue;
-        };
-
-        if !is_full_sha(ref_name) {
-            failures.push(format!(
-                "{relative_path}:{} action must be pinned to a full SHA",
-                line_number + 1
-            ));
-        }
     }
 }
 
@@ -348,13 +324,25 @@ fn should_skip_dir(root: &Path, path: &Path) -> bool {
         .is_some_and(|first_part| SKIPPED_DIRS.contains(&first_part))
 }
 
+fn is_blocked_sensitive_path(relative_path: &str) -> bool {
+    let lower_path = relative_path.to_ascii_lowercase();
+    BLOCKED_SENSITIVE_PATHS.contains(&lower_path.as_str())
+}
+
 fn is_blocked_filename(file_name: &str) -> bool {
     let lower_name = file_name.to_ascii_lowercase();
     BLOCKED_FILENAMES.contains(&lower_name.as_str())
-        || (lower_name.starts_with(".env.") && lower_name != ".env.example")
+        || (lower_name.starts_with(".env.") && !is_environment_template(&lower_name))
         || BLOCKED_SECRET_SUFFIXES
             .iter()
             .any(|suffix| lower_name.ends_with(suffix))
+}
+
+fn is_environment_template(file_name: &str) -> bool {
+    matches!(
+        file_name.rsplit('.').next(),
+        Some("dist" | "example" | "sample" | "template")
+    )
 }
 
 fn is_binary_file(path: &Path) -> bool {
@@ -375,71 +363,6 @@ fn is_workflow_file(relative_path: &str, path: &Path) -> bool {
         )
 }
 
-fn contains_prefixed_token(content: &str, prefixes: &[&str], minimum_tail_len: usize) -> bool {
-    content
-        .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
-        .any(|token| {
-            prefixes.iter().any(|prefix| {
-                token.starts_with(prefix) && token.len() >= prefix.len() + minimum_tail_len
-            })
-        })
-}
-
-fn contains_aws_access_key(content: &str) -> bool {
-    content
-        .split(|character: char| !character.is_ascii_alphanumeric())
-        .any(|token| {
-            token.len() == 20
-                && (token.starts_with("AKIA") || token.starts_with("ASIA"))
-                && token
-                    .chars()
-                    .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit())
-        })
-}
-
-fn has_generic_secret_assignment(content: &str) -> bool {
-    content.lines().any(|line| {
-        let lower_line = line.to_ascii_lowercase();
-        let has_secret_key = ["api_key", "api-key", "secret", "token", "password"]
-            .iter()
-            .any(|keyword| lower_line.contains(keyword));
-
-        if !has_secret_key {
-            return false;
-        }
-
-        let Some(separator_index) = line.find(['=', ':']) else {
-            return false;
-        };
-
-        let assignment_value = line[separator_index + 1..].trim_start();
-        let Some(quote) = assignment_value.chars().next() else {
-            return false;
-        };
-
-        if quote != '"' && quote != '\'' {
-            return false;
-        }
-
-        let Some(end_index) = assignment_value[1..].find(quote) else {
-            return false;
-        };
-
-        let value = &assignment_value[1..=end_index];
-        value.len() >= 20
-            && value
-                .chars()
-                .all(|character| character.is_ascii_alphanumeric() || "_./+=:-".contains(character))
-    })
-}
-
-fn is_full_sha(ref_name: &str) -> bool {
-    ref_name.len() == 40
-        && ref_name
-            .chars()
-            .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
-}
-
 fn relative_path(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -450,43 +373,33 @@ fn relative_path(root: &Path, path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        contains_aws_access_key, contains_prefixed_token, has_generic_secret_assignment,
-        is_blocked_filename, is_full_sha, should_skip_dir,
+        is_binary_file, is_blocked_filename, is_blocked_sensitive_path, should_skip_dir,
     };
     use std::path::Path;
 
     #[test]
-    fn detects_github_token_shape() {
-        let probe = format!("token = 'ghp_{}'", "a".repeat(36));
-        assert!(contains_prefixed_token(&probe, &["ghp_"], 30));
-    }
-
-    #[test]
-    fn detects_aws_access_key_shape() {
-        let probe = ["AKIA", "ABCDEFGHIJKLMNOP"].concat();
-        assert!(contains_aws_access_key(&probe));
-    }
-
-    #[test]
-    fn detects_generic_secret_assignment() {
-        let keyword = ["pass", "word"].concat();
-        let probe = format!("{keyword} = '{}'", "abcdefghijklmnopqrstuvwxyz");
-        assert!(has_generic_secret_assignment(&probe));
-    }
-
-    #[test]
-    fn requires_full_lowercase_sha() {
-        assert!(is_full_sha("9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"));
-        assert!(!is_full_sha("v4"));
-    }
-
-    #[test]
-    fn blocks_environment_and_key_container_filenames() {
+    fn distinguishes_sensitive_files_from_templates() {
         assert!(is_blocked_filename(".env.production"));
         assert!(is_blocked_filename("service-account.json"));
         assert!(is_blocked_filename("signing.P12"));
+        assert!(is_blocked_filename("vault.kdbx"));
         assert!(!is_blocked_filename(".env.example"));
+        assert!(!is_blocked_filename(".env.production.sample"));
         assert!(!is_blocked_filename("public-certificate.pem"));
+    }
+
+    #[test]
+    fn blocks_root_credential_paths() {
+        assert!(is_blocked_sensitive_path(".aws/credentials"));
+        assert!(is_blocked_sensitive_path(".KUBE/config"));
+        assert!(!is_blocked_sensitive_path("docs/.aws/credentials"));
+    }
+
+    #[test]
+    fn recognizes_binary_extensions_case_insensitively() {
+        assert!(is_binary_file(Path::new("archive.ZIP")));
+        assert!(is_binary_file(Path::new("fixture.DOCX")));
+        assert!(!is_binary_file(Path::new("README.md")));
     }
 
     #[test]

--- a/src/bin/check_repo.rs
+++ b/src/bin/check_repo.rs
@@ -110,9 +110,9 @@ const SKIPPED_DIRS: &[&str] = &[
 
 const BINARY_SUFFIXES: &[&str] = &[
     "7z", "a", "avi", "bmp", "class", "dmg", "doc", "docx", "dylib", "eot", "exe", "flac", "gif",
-    "gz", "ico", "jar", "jpeg", "jpg", "m4a", "mov", "mp3", "mp4", "o", "otf", "pdf", "png",
-    "ppt", "pptx", "so", "tar", "tiff", "ttf", "wav", "webm", "webp", "woff", "woff2", "xls",
-    "xlsx", "zip",
+    "gz", "ico", "jar", "jpeg", "jpg", "m4a", "mov", "mp3", "mp4", "o", "otf", "pdf", "png", "ppt",
+    "pptx", "so", "tar", "tiff", "ttf", "wav", "webm", "webp", "woff", "woff2", "xls", "xlsx",
+    "zip",
 ];
 
 const BLOCKED_FILENAMES: &[&str] = &[
@@ -129,14 +129,7 @@ const BLOCKED_FILENAMES: &[&str] = &[
     "service-account.json",
 ];
 
-const BLOCKED_SECRET_SUFFIXES: &[&str] = &[
-    ".jks",
-    ".key",
-    ".kdbx",
-    ".keystore",
-    ".p12",
-    ".pfx",
-];
+const BLOCKED_SECRET_SUFFIXES: &[&str] = &[".jks", ".key", ".kdbx", ".keystore", ".p12", ".pfx"];
 
 const BLOCKED_SENSITIVE_PATHS: &[&str] = &[
     ".aws/credentials",
@@ -372,9 +365,7 @@ fn relative_path(root: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        is_binary_file, is_blocked_filename, is_blocked_sensitive_path, should_skip_dir,
-    };
+    use super::{is_binary_file, is_blocked_filename, is_blocked_sensitive_path, should_skip_dir};
     use std::path::Path;
 
     #[test]
@@ -407,6 +398,7 @@ mod tests {
         let root = Path::new("/repo");
         assert!(should_skip_dir(root, &root.join("worktrees/transmission")));
         assert!(should_skip_dir(root, &root.join("backups/archive")));
+        assert!(!is_blocked_sensitive_path("docs/worktrees"));
         assert!(!should_skip_dir(root, &root.join("docs/worktrees")));
     }
 }

--- a/src/bin/check_repo/secrets.rs
+++ b/src/bin/check_repo/secrets.rs
@@ -1,0 +1,451 @@
+// Copyright 2026 Jean-Claude Joanna
+// SPDX-License-Identifier: Apache-2.0
+
+const PREFIXED_SECRET_RULES: &[(&str, &[&str], usize)] = &[
+    (
+        "GitHub token",
+        &["ghp_", "gho_", "ghu_", "ghs_", "ghr_"],
+        30,
+    ),
+    ("GitHub fine-grained token", &["github_pat_"], 20),
+    ("GitLab personal access token", &["glpat-"], 20),
+    ("OpenAI API key", &["sk-proj-", "sk-svcacct-"], 20),
+    ("Slack token", &["xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-"], 20),
+    ("Stripe live secret key", &["sk_live_", "rk_live_"], 16),
+    ("npm access token", &["npm_"], 30),
+    ("Google API key", &["AIza"], 30),
+    ("SendGrid API key", &["SG."], 40),
+];
+
+const SECRET_KEY_SUFFIXES: &[&str] = &[
+    "access-token",
+    "access_token",
+    "accesstoken",
+    "api-key",
+    "api_key",
+    "apikey",
+    "auth-token",
+    "auth_token",
+    "authtoken",
+    "bearer-token",
+    "bearer_token",
+    "bearertoken",
+    "client-secret",
+    "client_secret",
+    "clientsecret",
+    "password",
+    "passwd",
+    "private-key",
+    "private_key",
+    "privatekey",
+    "pwd",
+    "refresh-token",
+    "refresh_token",
+    "refreshtoken",
+    "secret",
+    "secret-key",
+    "secret_key",
+    "secretkey",
+    "signing-key",
+    "signing_key",
+    "signingkey",
+    "token",
+    "webhook-secret",
+    "webhook_secret",
+    "webhooksecret",
+];
+
+const PLACEHOLDER_MARKERS: &[&str] = &[
+    "changeme",
+    "dummy-secret",
+    "dummy_secret",
+    "example",
+    "not-a-real",
+    "not_real",
+    "placeholder",
+    "redacted",
+    "replace-me",
+    "replace_me",
+    "sample-secret",
+    "sample_secret",
+    "your-api",
+    "your-secret",
+    "your-token",
+    "your_api",
+    "your_secret",
+    "your_token",
+];
+
+const PRIVATE_KEY_PREFIX: &str = "-----BEGIN ";
+const PRIVATE_KEY_WORDS: [&str; 2] = ["PRIVATE ", "KEY-----"];
+const SECRET_ASSIGNMENT_THRESHOLD: u8 = 65;
+
+pub(crate) fn check_secret_content(
+    relative_path: &str,
+    content: &str,
+    failures: &mut Vec<String>,
+) {
+    let private_key_suffix = PRIVATE_KEY_WORDS.concat();
+    if content.contains(PRIVATE_KEY_PREFIX) && content.contains(&private_key_suffix) {
+        failures.push(format!(
+            "{relative_path} appears to contain private key block"
+        ));
+    }
+
+    for &(label, prefixes, minimum_tail_len) in PREFIXED_SECRET_RULES {
+        if contains_prefixed_token(content, prefixes, minimum_tail_len) {
+            failures.push(format!("{relative_path} appears to contain {label}"));
+        }
+    }
+
+    if contains_aws_access_key(content) {
+        failures.push(format!(
+            "{relative_path} appears to contain AWS access key id"
+        ));
+    }
+
+    if let Some((line_number, score)) = highest_secret_assignment_score(content) {
+        failures.push(format!(
+            "{relative_path}:{line_number} appears to contain likely secret assignment (signal score {score}/100)"
+        ));
+    }
+}
+
+fn contains_prefixed_token(content: &str, prefixes: &[&str], minimum_tail_len: usize) -> bool {
+    content
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.'))
+        })
+        .any(|token| {
+            prefixes.iter().any(|prefix| {
+                token.starts_with(prefix)
+                    && token.len() >= prefix.len() + minimum_tail_len
+                    && !is_placeholder_value(token)
+            })
+        })
+}
+
+fn contains_aws_access_key(content: &str) -> bool {
+    content
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| {
+            token.len() == 20
+                && (token.starts_with("AKIA") || token.starts_with("ASIA"))
+                && token
+                    .chars()
+                    .all(|character| character.is_ascii_uppercase() || character.is_ascii_digit())
+        })
+}
+
+fn highest_secret_assignment_score(content: &str) -> Option<(usize, u8)> {
+    content
+        .lines()
+        .enumerate()
+        .filter_map(|(line_index, line)| {
+            let score = secret_assignment_score(line);
+            (score >= SECRET_ASSIGNMENT_THRESHOLD).then_some((line_index + 1, score))
+        })
+        .max_by_key(|&(_, score)| score)
+}
+
+fn secret_assignment_score(line: &str) -> u8 {
+    let Some(separator_index) = find_assignment_separator(line) else {
+        return 0;
+    };
+    let key_score = secret_key_score(&line[..separator_index]);
+    if key_score == 0 {
+        return 0;
+    }
+
+    let Some(value) = extract_assignment_value(line, separator_index) else {
+        return 0;
+    };
+    if !(20..=512).contains(&value.len()) || is_placeholder_value(value) {
+        return 0;
+    }
+
+    let Some(features) = secret_value_features(value) else {
+        return 0;
+    };
+
+    let length_score = match value.len() {
+        64.. => 30,
+        48..=63 => 25,
+        32..=47 => 20,
+        _ => 15,
+    };
+    let class_score = match features.class_count {
+        4 => 25,
+        3 => 22,
+        2 => 15,
+        _ if value.len() >= 32 => 5,
+        _ => 0,
+    };
+    let distinct_score = match features.distinct_count {
+        16.. => 20,
+        10..=15 => 15,
+        6..=9 => 10,
+        _ => 0,
+    };
+
+    key_score
+        .saturating_add(length_score)
+        .saturating_add(class_score)
+        .saturating_add(distinct_score)
+        .min(100)
+}
+
+fn find_assignment_separator(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte != b'=' {
+            continue;
+        }
+
+        let previous = index.checked_sub(1).and_then(|position| bytes.get(position));
+        let next = bytes.get(index + 1);
+        if previous.is_some_and(|value| matches!(*value, b'=' | b'!' | b'<' | b'>'))
+            || next.is_some_and(|value| matches!(*value, b'=' | b'>'))
+        {
+            continue;
+        }
+
+        return Some(index);
+    }
+
+    line.find(':')
+}
+
+fn secret_key_score(key_part: &str) -> u8 {
+    key_part
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+        })
+        .filter(|candidate| !candidate.is_empty())
+        .filter_map(score_secret_key_name)
+        .max()
+        .unwrap_or(0)
+}
+
+fn score_secret_key_name(candidate: &str) -> Option<u8> {
+    let lower_candidate = candidate.to_ascii_lowercase();
+    SECRET_KEY_SUFFIXES.iter().find_map(|suffix| {
+        if lower_candidate == *suffix {
+            return Some(35);
+        }
+
+        let prefix = lower_candidate.strip_suffix(*suffix)?;
+        if prefix.ends_with('_') || prefix.ends_with('-') {
+            Some(32)
+        } else if !prefix.is_empty() {
+            Some(24)
+        } else {
+            None
+        }
+    })
+}
+
+fn extract_assignment_value(line: &str, separator_index: usize) -> Option<&str> {
+    let value_text = line.get(separator_index + 1..)?.trim_start();
+    let first_character = value_text.chars().next()?;
+
+    if matches!(first_character, '"' | '\'') {
+        let rest = &value_text[first_character.len_utf8()..];
+        let mut escaped = false;
+
+        for (index, character) in rest.char_indices() {
+            if character == first_character && !escaped {
+                return Some(&rest[..index]);
+            }
+
+            if character == '\\' {
+                escaped = !escaped;
+            } else {
+                escaped = false;
+            }
+        }
+
+        return None;
+    }
+
+    let end_index = value_text
+        .char_indices()
+        .find(|(_, character)| {
+            character.is_ascii_whitespace() || matches!(character, ',' | ';' | '#')
+        })
+        .map_or(value_text.len(), |(index, _)| index);
+
+    Some(&value_text[..end_index])
+}
+
+struct SecretValueFeatures {
+    class_count: usize,
+    distinct_count: usize,
+}
+
+fn secret_value_features(value: &str) -> Option<SecretValueFeatures> {
+    let mut has_lowercase = false;
+    let mut has_uppercase = false;
+    let mut has_digit = false;
+    let mut has_symbol = false;
+    let mut seen = [false; 128];
+
+    for byte in value.bytes() {
+        if !(byte.is_ascii_alphanumeric() || b"_./+=:@-".contains(&byte)) {
+            return None;
+        }
+
+        has_lowercase |= byte.is_ascii_lowercase();
+        has_uppercase |= byte.is_ascii_uppercase();
+        has_digit |= byte.is_ascii_digit();
+        has_symbol |= !byte.is_ascii_alphanumeric();
+        seen[usize::from(byte)] = true;
+    }
+
+    let class_count = [has_lowercase, has_uppercase, has_digit, has_symbol]
+        .into_iter()
+        .filter(|present| *present)
+        .count();
+    let distinct_count = seen.into_iter().filter(|present| *present).count();
+
+    Some(SecretValueFeatures {
+        class_count,
+        distinct_count,
+    })
+}
+
+fn is_placeholder_value(value: &str) -> bool {
+    let lower_value = value.trim().to_ascii_lowercase();
+    if lower_value.is_empty()
+        || lower_value.starts_with('$')
+        || lower_value.starts_with("{{")
+        || lower_value.starts_with('<')
+        || lower_value.contains("${")
+        || lower_value.contains("secrets.")
+        || lower_value.contains("process.env")
+        || lower_value.contains("std::env")
+        || lower_value.contains("os.environ")
+    {
+        return true;
+    }
+
+    if PLACEHOLDER_MARKERS
+        .iter()
+        .any(|marker| lower_value.contains(marker))
+    {
+        return true;
+    }
+
+    let mut seen = [false; 128];
+    for byte in lower_value.bytes() {
+        if byte.is_ascii() {
+            seen[usize::from(byte)] = true;
+        }
+    }
+
+    seen.into_iter().filter(|present| *present).count() <= 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        check_secret_content, contains_aws_access_key, contains_prefixed_token,
+        secret_assignment_score,
+    };
+
+    #[test]
+    fn detects_prefixed_provider_token_shapes() {
+        let probes = [
+            format!("ghp_{}", "A7z9".repeat(9)),
+            format!("glpat-{}", "A7z9".repeat(6)),
+            format!("sk-proj-{}", "A7z9".repeat(6)),
+            format!("xoxb-{}", "A7z9".repeat(6)),
+            format!("sk_live_{}", "A7z9".repeat(5)),
+            format!("npm_{}", "A7z9".repeat(8)),
+            format!("AIza{}", "A7z9".repeat(8)),
+            format!("SG.{}", "A7z9".repeat(11)),
+        ];
+
+        for probe in probes {
+            let mut failures = Vec::new();
+            check_secret_content("probe.txt", &probe, &mut failures);
+            assert!(!failures.is_empty(), "missed provider probe: {probe}");
+        }
+    }
+
+    #[test]
+    fn ignores_prefixed_placeholders() {
+        assert!(!contains_prefixed_token(
+            "sk-proj-example-placeholder-value-that-is-long",
+            &["sk-proj-"],
+            20
+        ));
+    }
+
+    #[test]
+    fn detects_aws_access_key_shape() {
+        let probe = ["AKIA", "ABCDEFGHIJKLMNOP"].concat();
+        assert!(contains_aws_access_key(&probe));
+    }
+
+    #[test]
+    fn keeps_secret_assignment_average_precision_above_floor() {
+        let generated = "A7z9_Qp2".repeat(4);
+        let corpus = [
+            (format!("export SERVICE_API_KEY={generated}"), true),
+            (format!("\"client_secret\": \"{generated}\","), true),
+            (format!("let accessToken: &str = \"{generated}\";"), true),
+            (format!("password: {generated} # deployment value"), true),
+            ("API_KEY=your_api_key_here".to_owned(), false),
+            ("client_secret = \"${CLIENT_SECRET}\"".to_owned(), false),
+            ("token_count = \"A7z9_Qp2A7z9_Qp2A7z9_Qp2\"".to_owned(), false),
+            ("secretary = \"A7z9_Qp2A7z9_Qp2A7z9_Qp2\"".to_owned(), false),
+            ("password = \"redacted-redacted-redacted\"".to_owned(), false),
+            ("api_key = \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"".to_owned(), false),
+        ];
+        let scored = corpus
+            .iter()
+            .map(|(probe, positive)| (secret_assignment_score(probe), *positive))
+            .collect::<Vec<_>>();
+
+        assert!(average_precision(&scored) >= 0.95);
+    }
+
+    fn average_precision(scored_labels: &[(u8, bool)]) -> f64 {
+        let positive_count = scored_labels.iter().filter(|(_, positive)| *positive).count();
+        assert!(positive_count > 0);
+
+        let mut thresholds = scored_labels
+            .iter()
+            .map(|(score, _)| *score)
+            .collect::<Vec<_>>();
+        thresholds.sort_unstable_by(|left, right| right.cmp(left));
+        thresholds.dedup();
+
+        let mut previous_recall = 0.0;
+        let mut area = 0.0;
+        for threshold in thresholds {
+            let selected_count = scored_labels
+                .iter()
+                .filter(|(score, _)| *score >= threshold)
+                .count();
+            let true_positives = scored_labels
+                .iter()
+                .filter(|(score, positive)| *score >= threshold && *positive)
+                .count();
+            let precision = ratio(true_positives, selected_count);
+            let recall = ratio(true_positives, positive_count);
+            area += (recall - previous_recall) * precision;
+            previous_recall = recall;
+        }
+
+        area
+    }
+
+    fn ratio(numerator: usize, denominator: usize) -> f64 {
+        let numerator = u32::try_from(numerator).expect("test corpus fits in u32");
+        let denominator = u32::try_from(denominator).expect("test corpus fits in u32");
+        f64::from(numerator) / f64::from(denominator)
+    }
+}

--- a/src/bin/check_repo/secrets.rs
+++ b/src/bin/check_repo/secrets.rs
@@ -10,7 +10,11 @@ const PREFIXED_SECRET_RULES: &[(&str, &[&str], usize)] = &[
     ("GitHub fine-grained token", &["github_pat_"], 20),
     ("GitLab personal access token", &["glpat-"], 20),
     ("OpenAI API key", &["sk-proj-", "sk-svcacct-"], 20),
-    ("Slack token", &["xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-"], 20),
+    (
+        "Slack token",
+        &["xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-"],
+        20,
+    ),
     ("Stripe live secret key", &["sk_live_", "rk_live_"], 16),
     ("npm access token", &["npm_"], 30),
     ("Google API key", &["AIza"], 30),
@@ -80,11 +84,7 @@ const PRIVATE_KEY_PREFIX: &str = "-----BEGIN ";
 const PRIVATE_KEY_WORDS: [&str; 2] = ["PRIVATE ", "KEY-----"];
 const SECRET_ASSIGNMENT_THRESHOLD: u8 = 65;
 
-pub(crate) fn check_secret_content(
-    relative_path: &str,
-    content: &str,
-    failures: &mut Vec<String>,
-) {
+pub(crate) fn check_secret_content(relative_path: &str, content: &str, failures: &mut Vec<String>) {
     let private_key_suffix = PRIVATE_KEY_WORDS.concat();
     if content.contains(PRIVATE_KEY_PREFIX) && content.contains(&private_key_suffix) {
         failures.push(format!(
@@ -203,7 +203,9 @@ fn find_assignment_separator(line: &str) -> Option<usize> {
             continue;
         }
 
-        let previous = index.checked_sub(1).and_then(|position| bytes.get(position));
+        let previous = index
+            .checked_sub(1)
+            .and_then(|position| bytes.get(position));
         let next = bytes.get(index + 1);
         if previous.is_some_and(|value| matches!(*value, b'=' | b'!' | b'<' | b'>'))
             || next.is_some_and(|value| matches!(*value, b'=' | b'>'))
@@ -399,10 +401,19 @@ mod tests {
             (format!("password: {generated} # deployment value"), true),
             ("API_KEY=your_api_key_here".to_owned(), false),
             ("client_secret = \"${CLIENT_SECRET}\"".to_owned(), false),
-            ("token_count = \"A7z9_Qp2A7z9_Qp2A7z9_Qp2\"".to_owned(), false),
+            (
+                "token_count = \"A7z9_Qp2A7z9_Qp2A7z9_Qp2\"".to_owned(),
+                false,
+            ),
             ("secretary = \"A7z9_Qp2A7z9_Qp2A7z9_Qp2\"".to_owned(), false),
-            ("password = \"redacted-redacted-redacted\"".to_owned(), false),
-            ("api_key = \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"".to_owned(), false),
+            (
+                "password = \"redacted-redacted-redacted\"".to_owned(),
+                false,
+            ),
+            (
+                "api_key = \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"".to_owned(),
+                false,
+            ),
         ];
         let scored = corpus
             .iter()
@@ -413,7 +424,10 @@ mod tests {
     }
 
     fn average_precision(scored_labels: &[(u8, bool)]) -> f64 {
-        let positive_count = scored_labels.iter().filter(|(_, positive)| *positive).count();
+        let positive_count = scored_labels
+            .iter()
+            .filter(|(_, positive)| *positive)
+            .count();
         assert!(positive_count > 0);
 
         let mut thresholds = scored_labels

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -151,9 +151,8 @@ fn inline_permissions_grant_contents_write(value: &str) -> bool {
     };
 
     inner.split(',').any(|entry| {
-        yaml_key_value(entry).is_some_and(|(key, value)| {
-            key == "contents" && trim_yaml_scalar(value) == "write"
-        })
+        yaml_key_value(entry)
+            .is_some_and(|(key, value)| key == "contents" && trim_yaml_scalar(value) == "write")
     })
 }
 

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -1,0 +1,236 @@
+// Copyright 2026 Jean-Claude Joanna
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) fn check_workflow_content(
+    relative_path: &str,
+    content: &str,
+    failures: &mut Vec<String>,
+) {
+    let mut permissions_indent = None;
+
+    for (line_number, raw_line) in content.lines().enumerate() {
+        let line = strip_yaml_comment(raw_line);
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() {
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if permissions_indent.is_some_and(|block_indent| indent <= block_indent) {
+            permissions_indent = None;
+        }
+
+        if let Some((key, value)) = yaml_key_value(trimmed_line) {
+            let scalar_value = trim_yaml_scalar(value);
+            if key == "permissions" {
+                if scalar_value == "write-all" {
+                    failures.push(format!(
+                        "{relative_path}:{} must not use write-all permissions",
+                        line_number + 1
+                    ));
+                }
+
+                if inline_permissions_grant_contents_write(value) {
+                    failures.push(format!(
+                        "{relative_path}:{} must not grant contents: write",
+                        line_number + 1
+                    ));
+                }
+
+                if value.is_empty() {
+                    permissions_indent = Some(indent);
+                }
+            } else if key == "contents"
+                && scalar_value == "write"
+                && permissions_indent.is_some_and(|block_indent| indent > block_indent)
+            {
+                failures.push(format!(
+                    "{relative_path}:{} must not grant contents: write",
+                    line_number + 1
+                ));
+            }
+        }
+
+        let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
+        let Some((key, value)) = yaml_key_value(step_line) else {
+            continue;
+        };
+        if key != "uses" {
+            continue;
+        }
+
+        let action_ref = trim_yaml_scalar(value)
+            .split_whitespace()
+            .next()
+            .unwrap_or("");
+
+        if action_ref.starts_with("./") {
+            continue;
+        }
+
+        if action_ref.starts_with("docker://") {
+            if !is_pinned_docker_reference(action_ref) {
+                failures.push(format!(
+                    "{relative_path}:{} Docker action must use a sha256 digest",
+                    line_number + 1
+                ));
+            }
+            continue;
+        }
+
+        let Some((_, ref_name)) = action_ref.rsplit_once('@') else {
+            failures.push(format!(
+                "{relative_path}:{} action is unpinned",
+                line_number + 1
+            ));
+            continue;
+        };
+
+        if !is_full_sha(ref_name) {
+            failures.push(format!(
+                "{relative_path}:{} action must be pinned to a full SHA",
+                line_number + 1
+            ));
+        }
+    }
+}
+
+fn strip_yaml_comment(line: &str) -> &str {
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escaped = false;
+
+    for (index, character) in line.char_indices() {
+        if character == '\\' && in_double_quotes {
+            escaped = !escaped;
+            continue;
+        }
+
+        if character == '"' && !in_single_quotes && !escaped {
+            in_double_quotes = !in_double_quotes;
+        } else if character == '\'' && !in_double_quotes {
+            in_single_quotes = !in_single_quotes;
+        } else if character == '#'
+            && !in_single_quotes
+            && !in_double_quotes
+            && (index == 0
+                || line[..index]
+                    .chars()
+                    .next_back()
+                    .is_some_and(char::is_whitespace))
+        {
+            return &line[..index];
+        }
+
+        if character != '\\' {
+            escaped = false;
+        }
+    }
+
+    line
+}
+
+fn yaml_key_value(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(':')?;
+    Some((trim_yaml_scalar(key), value.trim()))
+}
+
+fn trim_yaml_scalar(value: &str) -> &str {
+    value
+        .trim()
+        .trim_matches(|character| character == '"' || character == '\'')
+}
+
+fn inline_permissions_grant_contents_write(value: &str) -> bool {
+    let Some(inner) = value
+        .trim()
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+    else {
+        return false;
+    };
+
+    inner.split(',').any(|entry| {
+        yaml_key_value(entry).is_some_and(|(key, value)| {
+            key == "contents" && trim_yaml_scalar(value) == "write"
+        })
+    })
+}
+
+fn is_pinned_docker_reference(reference: &str) -> bool {
+    let Some((image, digest)) = reference.rsplit_once("@sha256:") else {
+        return false;
+    };
+
+    image.len() > "docker://".len()
+        && digest.len() == 64
+        && digest
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+}
+
+fn is_full_sha(ref_name: &str) -> bool {
+    ref_name.len() == 40
+        && ref_name
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{check_workflow_content, is_full_sha, is_pinned_docker_reference};
+
+    #[test]
+    fn parses_workflow_permissions_in_context() {
+        let safe = r#"
+permissions:
+  contents: read
+jobs:
+  smoke:
+    steps:
+      - name: Example input
+        with:
+          contents: write
+# permissions: write-all
+"#;
+        let unsafe_workflow = r#"
+permissions: "write-all"
+jobs:
+  smoke:
+    permissions:
+      contents: 'write'
+"#;
+
+        let mut safe_failures = Vec::new();
+        check_workflow_content("safe.yml", safe, &mut safe_failures);
+        assert!(safe_failures.is_empty());
+
+        let mut unsafe_failures = Vec::new();
+        check_workflow_content("unsafe.yml", unsafe_workflow, &mut unsafe_failures);
+        assert_eq!(unsafe_failures.len(), 2);
+    }
+
+    #[test]
+    fn detects_inline_write_permissions() {
+        let workflow = "permissions: { contents: 'write', issues: read }";
+        let mut failures = Vec::new();
+        check_workflow_content("inline.yml", workflow, &mut failures);
+        assert_eq!(failures.len(), 1);
+    }
+
+    #[test]
+    fn requires_docker_actions_to_use_sha256_digests() {
+        let digest = "a".repeat(64);
+        assert!(is_pinned_docker_reference(&format!(
+            "docker://alpine@sha256:{digest}"
+        )));
+        assert!(!is_pinned_docker_reference("docker://alpine:latest"));
+    }
+
+    #[test]
+    fn accepts_full_hexadecimal_action_shas() {
+        assert!(is_full_sha("9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"));
+        assert!(is_full_sha("9C091BB21B7C1C1D1991BB908D89E4E9DDDFE3E0"));
+        assert!(!is_full_sha("v4"));
+    }
+}

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn parses_workflow_permissions_in_context() {
-        let safe = r#"
+        let safe = r"
 permissions:
   contents: read
 jobs:
@@ -191,7 +191,7 @@ jobs:
         with:
           contents: write
 # permissions: write-all
-"#;
+";
         let unsafe_workflow = r#"
 permissions: "write-all"
 jobs:


### PR DESCRIPTION
## Summary

- Split secret and workflow classification into focused Rust modules while keeping the doctor dependency-free.
- Replace broad secret-key substring matching with scored key-aware assignments, placeholder suppression, unquoted value support, and provider-specific token signatures.
- Add a labeled positive/negative regression corpus with a `0.95` average-precision floor.
- Allow environment template variants while blocking common root credential stores and KeePass databases.
- Parse workflow permissions in YAML context, ignore comments and unrelated `contents: write` inputs, and require Docker actions to use SHA-256 digests.

## Verification

- Protected `Repository smoke test` required before merge.
- The workflow runs `cargo fmt --check`, strict Clippy, locked tests, and the repository doctor.

## Risk / Notes

- No dependencies, scripts, or workflows added.
- The average-precision floor is an internal regression corpus, not a claim about an external production dataset.
- Findings retain one highest-scoring generic assignment per file to avoid duplicate-noise inflation.
