### PR TITLE
Group routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore"
 
@@ -15,5 +19,9 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 2
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ This project follows a simple chronological changelog. It is a learning reposito
   credential stores and password-manager databases.
 - Made workflow permission checks context-aware and required Docker actions to
   use immutable SHA-256 digests.
+- Grouped routine GitHub Actions and Cargo Dependabot updates by ecosystem to
+  reduce maintenance PR noise without disabling update coverage.
 - Reconciled the roadmap with completed issue and pull request practice.
 - Promoted the Rust-native repository doctor in the README with current checks and sample passing output.
 


### PR DESCRIPTION
## Summary

- Group GitHub Actions updates into one ecosystem PR.
- Group Cargo updates into one ecosystem PR.
- Keep the existing weekly cadence and two-PR ceiling while reducing maintenance noise.

## Why

The repository currently allows Dependabot to open separate PRs for every update. GitHub's current Dependabot configuration supports single-ecosystem `groups`, so this keeps coverage while making automation less spammy and easier to review.

## Verification

- Configuration uses the documented Dependabot v2 `groups` syntax.
- Protected `Repository smoke test` required before merge.

## Risk / Notes

- No dependency is ignored or delayed beyond the existing weekly schedule.
- Security update behavior remains governed by repository settings and GitHub's Dependabot security-update configuration.
