### PR TITLE
Cancel superseded CI runs

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   repository-smoke-test:
     name: Repository smoke test


### PR DESCRIPTION
## Summary

- Add workflow concurrency keyed by pull request or branch.
- Cancel older in-progress smoke tests when a newer commit supersedes them.

## Why

The required check is intentionally strict, but there is no value in burning runner time validating a commit that can no longer merge. This keeps the same protection while making iterative PR work faster and cheaper.

## Verification

- Existing protected check name stays `Repository smoke test`.
- Permissions, pinned checkout action, strict Rust checks, and repository doctor remain unchanged.
