### PR TITLE
Enforce GitHub Actions trust boundaries

### DIFF
--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -1,12 +1,20 @@
 // Copyright 2026 Jean-Claude Joanna
 // SPDX-License-Identifier: Apache-2.0
 
+#[derive(Default)]
+struct WorkflowState {
+    permissions_indent: Option<usize>,
+    trigger_indent: Option<usize>,
+    has_top_level_permissions: bool,
+    checkout_step: Option<(usize, bool)>,
+}
+
 pub(crate) fn check_workflow_content(
     relative_path: &str,
     content: &str,
     failures: &mut Vec<String>,
 ) {
-    let mut permissions_indent = None;
+    let mut state = WorkflowState::default();
 
     for (line_number, raw_line) in content.lines().enumerate() {
         let line = strip_yaml_comment(raw_line);
@@ -15,83 +23,196 @@ pub(crate) fn check_workflow_content(
             continue;
         }
 
+        let line_number = line_number + 1;
         let indent = line.len() - line.trim_start().len();
-        if permissions_indent.is_some_and(|block_indent| indent <= block_indent) {
-            permissions_indent = None;
+        update_block_state(&mut state, indent);
+
+        if trimmed_line.starts_with("- ") {
+            finish_checkout_step(relative_path, &mut state.checkout_step, failures);
         }
 
-        if let Some((key, value)) = yaml_key_value(trimmed_line) {
-            let scalar_value = trim_yaml_scalar(value);
-            if key == "permissions" {
-                if scalar_value == "write-all" {
-                    failures.push(format!(
-                        "{relative_path}:{} must not use write-all permissions",
-                        line_number + 1
-                    ));
-                }
+        check_yaml_policy(
+            relative_path,
+            trimmed_line,
+            indent,
+            line_number,
+            &mut state,
+            failures,
+        );
+        check_action_reference(
+            relative_path,
+            trimmed_line,
+            line_number,
+            &mut state.checkout_step,
+            failures,
+        );
+    }
 
-                if inline_permissions_grant_contents_write(value) {
-                    failures.push(format!(
-                        "{relative_path}:{} must not grant contents: write",
-                        line_number + 1
-                    ));
-                }
+    finish_checkout_step(relative_path, &mut state.checkout_step, failures);
+    if !state.has_top_level_permissions {
+        failures.push(format!(
+            "{relative_path} must declare top-level workflow permissions"
+        ));
+    }
+}
 
-                if value.is_empty() {
-                    permissions_indent = Some(indent);
-                }
-            } else if key == "contents"
-                && scalar_value == "write"
-                && permissions_indent.is_some_and(|block_indent| indent > block_indent)
-            {
-                failures.push(format!(
-                    "{relative_path}:{} must not grant contents: write",
-                    line_number + 1
-                ));
-            }
+fn update_block_state(state: &mut WorkflowState, indent: usize) {
+    if state
+        .permissions_indent
+        .is_some_and(|block_indent| indent <= block_indent)
+    {
+        state.permissions_indent = None;
+    }
+    if state
+        .trigger_indent
+        .is_some_and(|block_indent| indent <= block_indent)
+    {
+        state.trigger_indent = None;
+    }
+}
+
+fn check_yaml_policy(
+    relative_path: &str,
+    trimmed_line: &str,
+    indent: usize,
+    line_number: usize,
+    state: &mut WorkflowState,
+    failures: &mut Vec<String>,
+) {
+    let Some((key, value)) = yaml_key_value(trimmed_line) else {
+        return;
+    };
+    let scalar_value = trim_yaml_scalar(value);
+
+    if key == "on" && value.is_empty() {
+        state.trigger_indent = Some(indent);
+    } else if key == "pull_request_target"
+        && state
+            .trigger_indent
+            .is_some_and(|block_indent| indent > block_indent)
+    {
+        failures.push(format!(
+            "{relative_path}:{line_number} must not use pull_request_target"
+        ));
+    }
+
+    check_permissions(
+        relative_path,
+        key,
+        value,
+        scalar_value,
+        indent,
+        line_number,
+        state,
+        failures,
+    );
+
+    if key == "persist-credentials" && scalar_value == "false" {
+        if let Some((_, credentials_disabled)) = state.checkout_step.as_mut() {
+            *credentials_disabled = true;
         }
+    }
+}
 
-        let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
-        let Some((key, value)) = yaml_key_value(step_line) else {
-            continue;
-        };
-        if key != "uses" {
-            continue;
-        }
+#[allow(clippy::too_many_arguments)]
+fn check_permissions(
+    relative_path: &str,
+    key: &str,
+    value: &str,
+    scalar_value: &str,
+    indent: usize,
+    line_number: usize,
+    state: &mut WorkflowState,
+    failures: &mut Vec<String>,
+) {
+    if key == "permissions" {
+        state.has_top_level_permissions |= indent == 0;
 
-        let action_ref = trim_yaml_scalar(value)
-            .split_whitespace()
-            .next()
-            .unwrap_or("");
-
-        if action_ref.starts_with("./") {
-            continue;
-        }
-
-        if action_ref.starts_with("docker://") {
-            if !is_pinned_docker_reference(action_ref) {
-                failures.push(format!(
-                    "{relative_path}:{} Docker action must use a sha256 digest",
-                    line_number + 1
-                ));
-            }
-            continue;
-        }
-
-        let Some((_, ref_name)) = action_ref.rsplit_once('@') else {
+        if scalar_value == "write-all" {
             failures.push(format!(
-                "{relative_path}:{} action is unpinned",
-                line_number + 1
-            ));
-            continue;
-        };
-
-        if !is_full_sha(ref_name) {
-            failures.push(format!(
-                "{relative_path}:{} action must be pinned to a full SHA",
-                line_number + 1
+                "{relative_path}:{line_number} must not use write-all permissions"
             ));
         }
+        if inline_permissions_grant_contents_write(value) {
+            failures.push(format!(
+                "{relative_path}:{line_number} must not grant contents: write"
+            ));
+        }
+        if value.is_empty() {
+            state.permissions_indent = Some(indent);
+        }
+    } else if key == "contents"
+        && scalar_value == "write"
+        && state
+            .permissions_indent
+            .is_some_and(|block_indent| indent > block_indent)
+    {
+        failures.push(format!(
+            "{relative_path}:{line_number} must not grant contents: write"
+        ));
+    }
+}
+
+fn check_action_reference(
+    relative_path: &str,
+    trimmed_line: &str,
+    line_number: usize,
+    checkout_step: &mut Option<(usize, bool)>,
+    failures: &mut Vec<String>,
+) {
+    let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
+    let Some((key, value)) = yaml_key_value(step_line) else {
+        return;
+    };
+    if key != "uses" {
+        return;
+    }
+
+    let action_ref = trim_yaml_scalar(value)
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    let action_name = action_ref
+        .split_once('@')
+        .map_or(action_ref, |(name, _)| name);
+    if action_name == "actions/checkout" {
+        *checkout_step = Some((line_number, false));
+    }
+
+    if action_ref.starts_with("./") {
+        return;
+    }
+
+    if action_ref.starts_with("docker://") {
+        if !is_pinned_docker_reference(action_ref) {
+            failures.push(format!(
+                "{relative_path}:{line_number} Docker action must use a sha256 digest"
+            ));
+        }
+        return;
+    }
+
+    let Some((_, ref_name)) = action_ref.rsplit_once('@') else {
+        failures.push(format!("{relative_path}:{line_number} action is unpinned"));
+        return;
+    };
+
+    if !is_full_sha(ref_name) {
+        failures.push(format!(
+            "{relative_path}:{line_number} action must be pinned to a full SHA"
+        ));
+    }
+}
+
+fn finish_checkout_step(
+    relative_path: &str,
+    checkout_step: &mut Option<(usize, bool)>,
+    failures: &mut Vec<String>,
+) {
+    if let Some((line_number, false)) = checkout_step.take() {
+        failures.push(format!(
+            "{relative_path}:{line_number} actions/checkout must set persist-credentials: false"
+        ));
     }
 }
 
@@ -179,6 +300,8 @@ fn is_full_sha(ref_name: &str) -> bool {
 mod tests {
     use super::{check_workflow_content, is_full_sha, is_pinned_docker_reference};
 
+    const PINNED_CHECKOUT: &str = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+
     #[test]
     fn parses_workflow_permissions_in_context() {
         let safe = r"
@@ -207,6 +330,24 @@ jobs:
         let mut unsafe_failures = Vec::new();
         check_workflow_content("unsafe.yml", unsafe_workflow, &mut unsafe_failures);
         assert_eq!(unsafe_failures.len(), 2);
+    }
+
+    #[test]
+    fn enforces_workflow_trust_boundaries() {
+        let safe = format!(
+            "on:\n  pull_request:\npermissions:\n  contents: read\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n        with:\n          persist-credentials: false\n"
+        );
+        let unsafe_workflow = format!(
+            "on:\n  pull_request_target:\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n"
+        );
+
+        let mut safe_failures = Vec::new();
+        check_workflow_content("safe.yml", &safe, &mut safe_failures);
+        assert!(safe_failures.is_empty());
+
+        let mut unsafe_failures = Vec::new();
+        check_workflow_content("unsafe.yml", &unsafe_workflow, &mut unsafe_failures);
+        assert_eq!(unsafe_failures.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require every workflow to declare top-level token permissions.
- Reject `pull_request_target` triggers in this public learning repository.
- Require every `actions/checkout` step to disable persisted credentials.
- Keep the existing immutable SHA and Docker digest checks.

## Security rationale

The repository doctor already audits workflow pinning, so it should also enforce the adjacent token boundary. A pinned checkout can still leave the repository token in Git configuration for later steps, and `pull_request_target` deliberately runs in the base-repository security context. Neither behavior is needed here.

## Verification

- Added regression coverage for a safe checkout flow and for all three rejected trust-boundary conditions.
- Protected `Repository smoke test` required before merge.

## Risk / Notes

- This intentionally narrows future workflow design. A future workflow that genuinely needs elevated permissions must make that design change explicit instead of inheriting broad defaults.
