### PR TITLE
Automate and preserve protected quality gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,17 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 2
+      time: "06:00"
+      timezone: "Europe/Lisbon"
     groups:
-      github-actions:
+      routine-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"
 
@@ -18,10 +24,16 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 2
+      time: "06:00"
+      timezone: "Europe/Lisbon"
     groups:
-      cargo-dependencies:
+      routine-rust:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore"

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,6 +18,13 @@ permissions:
 concurrency:
   group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   repository-smoke-test:
@@ -28,18 +39,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check Rust project
-        shell: bash
-        run: |
-          cargo fmt --check
-          cargo clippy --locked --all-targets -- -D warnings
-          cargo test --locked
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Lint all targets
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Test all targets
+        run: cargo test --locked --all-targets --all-features
 
       - name: Run repository doctor
-        shell: bash
-        run: bash scripts/doctor.sh
-
-      - name: Print repository status
-        shell: bash
-        run: |
-          echo "Basic repository checks passed."
+        run: cargo run --quiet --locked --bin check_repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,16 @@ This project follows a simple chronological changelog. It is a learning reposito
   credential stores and password-manager databases.
 - Made workflow permission checks context-aware and required Docker actions to
   use immutable SHA-256 digests.
-- Grouped routine GitHub Actions and Cargo Dependabot updates by ecosystem to
-  reduce maintenance PR noise without disabling update coverage.
+- Enforced explicit top-level workflow token permissions, rejected
+  `pull_request_target`, and required checkout steps to disable persisted
+  credentials.
+- Expanded the protected Rust gate to all targets and features, direct doctor
+  execution, merge-queue commits, and manual dispatches while canceling stale
+  runs for the same pull request or ref.
+- Grouped routine Dependabot minor and patch updates by ecosystem on a fixed
+  Europe/Lisbon schedule while leaving major updates isolated for review.
+- Made the repository doctor assert the durable CI and Dependabot guarantees so
+  later edits cannot silently remove the automation baseline.
 - Reconciled the roadmap with completed issue and pull request practice.
 - Promoted the Rust-native repository doctor in the README with current checks and sample passing output.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is used for experimenting with GitHub workflows and basic projec
 
 It is not a production system, commercial product, managed service, professional recommendation, security tool, or operational dependency.
 
-## Start here
+## Start Here
 
 If you are new to GitHub, read [START_HERE.md](START_HERE.md) first. It explains the files in this repository, the basic GitHub words, and a tiny practice plan.
 
@@ -28,33 +28,42 @@ For hands-on setup and workflow notes, read:
 - [docs/GITHUB_WORKFLOW.md](docs/GITHUB_WORKFLOW.md)
 - [docs/PROJECT_STRUCTURE.md](docs/PROJECT_STRUCTURE.md)
 
-## Starter project
+## Starter Project
 
-This repository now uses a small Rust starter instead of a static web page:
+This repository uses a small Rust starter and a modular Rust-native repository doctor:
 
 ```text
 Cargo.toml
 Cargo.lock
 src/main.rs
 src/bin/check_repo.rs
+src/bin/check_repo/secrets.rs
+src/bin/check_repo/workflows.rs
 scripts/doctor.sh
 ```
 
-Edit the Rust or shell files to practice commits, branches, pull requests, and checks. The Rust code is intentionally small for now; it is a staging point, not a finished product.
+Edit the Rust, documentation, or configuration files to practice commits, branches, pull requests, and checks. The code is intentionally compact; it is a staging point, not a finished product.
 
-## What The Doctor Checks
+## What the Doctor Checks
 
-`src/bin/check_repo.rs` is the main project-specific tool in this repository. It verifies that the public repository stays small, readable, and safe to practice with:
+`src/bin/check_repo.rs` builds one deterministic repository inventory and coordinates the project-specific checks. The focused classifier modules keep detection logic testable instead of turning one file into a municipal landfill.
 
-- required project, policy, documentation, GitHub, Rust, and script files exist;
-- expected Rust safety references stay in place;
+The doctor verifies that:
+
+- required project, policy, documentation, GitHub, Rust, and local-helper files exist;
+- expected Rust safety and CI-policy references remain in place;
 - issue evidence artifacts are explicitly marked as redacted;
-- common sensitive filenames are not committed;
-- private-key blocks, GitHub-token shapes, AWS access-key shapes, and generic secret assignments are flagged;
-- GitHub Actions workflows avoid broad write permissions;
-- third-party GitHub Actions are pinned to full commit SHAs.
+- repository symlinks cannot silently escape the scan boundary;
+- sensitive filenames, key containers, password-manager databases, and common root credential stores are not committed;
+- private-key blocks, AWS access-key shapes, and provider-specific token shapes are flagged;
+- quoted and unquoted secret assignments are scored using key semantics, length, character classes, and value diversity;
+- placeholders, environment references, redacted values, and low-entropy examples are suppressed to reduce false positives;
+- GitHub Actions permissions are evaluated in YAML context rather than by blind substring matching;
+- third-party GitHub Actions use full commit SHAs and Docker actions use SHA-256 digests.
 
-Run it locally with:
+The secret-assignment classifier includes a labeled positive-and-negative regression corpus with an internal average-precision floor of `0.95`. That protects classifier behavior from silent regression; it is not a claim about performance on an external production dataset.
+
+Run the doctor locally with:
 
 ```bash
 bash scripts/doctor.sh
@@ -67,23 +76,38 @@ Repository check passed.
 Doctor check passed.
 ```
 
-## Current scope
+## Automated Quality Gate
+
+The required `Repository smoke test` runs formatting, strict Clippy checks, locked tests, and the repository doctor directly against every Rust target and feature.
+
+The same gate covers:
+
+- pull requests into `main`;
+- pushes to `main`;
+- merge-queue groups;
+- manual workflow dispatches.
+
+New commits cancel older in-progress runs for the same pull request or ref, so CI validates the current revision instead of burning runner time on archaeological layers. The doctor also asserts the important workflow and Dependabot settings, making those automation guarantees cumulative.
+
+Dependabot checks GitHub Actions and Cargo every Monday at 06:00 Europe/Lisbon time. Routine minor and patch updates are grouped by ecosystem; major updates remain separate for explicit review.
+
+## Current Scope
 
 - Repository setup
 - Beginner onboarding
 - README structure
 - Rust starter project
-- Rust-native repository doctor and shell wrapper
+- Modular Rust-native repository doctor and local shell wrapper
+- Scored secret-signal classification and internal precision/recall regression coverage
 - License and disclaimer hygiene
-- GitHub workflow practice
+- Protected branch, pull-request, merge-queue, and manual quality gates
 - Basic public-repository policy files
 - Issue and pull request templates
-- Basic GitHub Actions smoke checks
-- Weekly Dependabot checks for GitHub Actions and Cargo
-- Local and CI guards for common secret patterns, sensitive filenames, redacted evidence artifacts, workflow permissions, and pinned GitHub Actions
+- Grouped weekly Dependabot checks for GitHub Actions and Cargo
+- Local and CI guards for sensitive paths, secret patterns, redacted evidence artifacts, workflow permissions, and immutable action references
 - Funding status note
 
-## Important notices
+## Important Notices
 
 This repository is provided for learning, testing, and experimentation only. Use of this repository or its contents is voluntary and entirely at your own risk.
 
@@ -91,7 +115,7 @@ This repository is not production software, not professional advice, not a manag
 
 Do not use this repository with production credentials, secrets, private keys, API tokens, personal data, confidential information, customer data, regulated data, business-critical workflows, or security-sensitive systems.
 
-## Policies and project files
+## Policies and Project Files
 
 - [LICENSE](LICENSE) — Apache License 2.0 terms
 - [NOTICE](NOTICE) — copyright and project attribution notice
@@ -106,33 +130,34 @@ Do not use this repository with production credentials, secrets, private keys, A
 - [ROADMAP.md](ROADMAP.md) — future learning path and project ideas
 - [docs/PROJECT_STRUCTURE.md](docs/PROJECT_STRUCTURE.md) — current file layout
 
-## GitHub workflow helpers
+## GitHub Workflow Helpers
 
 This repository includes:
 
 - issue templates for bugs, features, and documentation tasks;
 - a pull request template;
-- a basic GitHub Actions workflow;
-- a small Rust test;
-- Rust and shell local checks;
-- weekly Dependabot checks for GitHub Actions and Cargo;
+- a protected GitHub Actions quality gate;
+- merge-queue and manual-run coverage;
+- stale-run cancellation;
+- Rust formatting, linting, tests, and project-specific checks;
+- grouped weekly Dependabot checks for GitHub Actions and Cargo;
 - public-repository hardening checks for secrets, redacted evidence artifacts, and GitHub workflow safety;
-- CODEOWNERS review visibility;
+- `CODEOWNERS` review visibility;
 - `.editorconfig` and `.gitattributes` for cleaner editing and diffs.
 
-## Funding status
+## Funding Status
 
 This repository does not currently expose active GitHub funding links. If funding is enabled later, any support will remain voluntary and will not create support, maintenance, consulting, service-level, feature, priority, warranty, or commercial obligations. See [SPONSORS.md](SPONSORS.md).
 
 A placeholder `.github/FUNDING.yml` exists for future funding metadata only.
 
-## Next steps
+## Next Steps
 
 - Edit the Rust starter
 - Create a branch
-- Make commits
+- Make focused commits
 - Open a pull request
-- Review the GitHub Actions result
+- Review the protected GitHub Actions result
 - Merge the pull request
 - Read the changelog and roadmap
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,6 +1,6 @@
 # GitHub Workflow
 
-This guide explains the basic workflow this repository is meant to teach.
+This guide explains the branch-to-merge workflow used by this repository.
 
 ## 1. Create a Branch
 
@@ -12,7 +12,7 @@ git checkout -b practice/my-first-change
 
 ## 2. Make a Small Change
 
-Edit a small file, such as:
+Edit a focused set of files, such as:
 
 ```text
 Cargo.toml
@@ -20,7 +20,7 @@ src/main.rs
 README.md
 ```
 
-Keep the change small so it is easy to review.
+Keep each change coherent so it is easy to review, test, and reverse.
 
 ## 3. Check What Changed
 
@@ -29,36 +29,63 @@ git status
 git diff
 ```
 
-## 4. Commit the Change
+## 4. Run Local Checks
+
+Run the same project-specific doctor used in CI:
+
+```bash
+bash scripts/doctor.sh
+```
+
+For the complete Rust gate, also run:
+
+```bash
+cargo fmt --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-targets --all-features
+```
+
+## 5. Commit the Change
 
 ```bash
 git add src/main.rs
 git commit -m "Practice first branch change"
 ```
 
-Replace `src/main.rs` with the file you actually changed.
+Replace `src/main.rs` with the files you actually changed.
 
-## 5. Push the Branch
+## 6. Push the Branch
 
 ```bash
 git push -u origin practice/my-first-change
 ```
 
-## 6. Open a Pull Request
+## 7. Open a Pull Request
 
-On GitHub, open a pull request from your branch into `main`.
+Open a pull request from the branch into `main`.
 
 Use the pull request template and confirm that no secrets, credentials, personal data, or confidential information are included.
 
-## 7. Review Checks
+## 8. Review the Protected Check
 
-GitHub Actions will run basic repository checks.
+The required `Repository smoke test` runs four direct gates:
 
-If a check fails, read the message, fix the issue, commit again, and push again.
+1. Rust formatting;
+2. strict Clippy checks across all targets and features;
+3. locked tests across all targets and features;
+4. the Rust repository doctor.
 
-## 8. Merge
+The same gate runs for pull requests, pushes to `main`, merge-queue groups, and manual dispatches. When another commit reaches the same pull request, the older in-progress run is canceled so only the current revision consumes CI time.
 
-When the change is reviewed and the checks are acceptable, merge the pull request.
+If the check fails, open the failed step, fix the reported defect, and push the correction to the same branch.
+
+## 9. Merge
+
+Merge only after the required check passes. The merge queue, when used, runs the same check against the proposed merge-group commit rather than trusting an earlier pull-request result.
+
+## Dependency Updates
+
+Dependabot checks GitHub Actions and Cargo every Monday at 06:00 Europe/Lisbon time. Routine minor and patch updates are grouped by ecosystem, while major updates remain separate for explicit review.
 
 ## Safety Rules
 
@@ -68,7 +95,7 @@ Do not commit:
 - API keys;
 - tokens;
 - private keys;
-- `.env` files;
+- live `.env` files;
 - personal data;
 - customer data;
 - confidential information;

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -32,35 +32,37 @@ This document explains the current repository layout.
 | --- | --- |
 | `docs/PROJECT_STRUCTURE.md` | Current repository layout. |
 | `docs/LOCAL_SETUP.md` | How to clone, open, edit, and commit locally. |
-| `docs/GITHUB_WORKFLOW.md` | Branch, commit, push, pull request, and merge workflow. |
+| `docs/GITHUB_WORKFLOW.md` | Branch, commit, protected-check, merge-queue, and dependency-update workflow. |
 
 ## Source Files
 
 | Path | Purpose |
 | --- | --- |
 | `src/main.rs` | Small Rust starter program. |
-| `src/bin/check_repo.rs` | Rust repository doctor for structure, evidence, secret-pattern, and workflow checks. |
+| `src/bin/check_repo.rs` | Repository inventory, required-file policy, sensitive-path checks, and classifier orchestration. |
+| `src/bin/check_repo/secrets.rs` | Provider signatures and scored secret-assignment classification with precision/recall regression tests. |
+| `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions permission and immutable-reference checks. |
 
 ## Scripts
 
 | Path | Purpose |
 | --- | --- |
-| `scripts/doctor.sh` | Shell wrapper for the Rust repository doctor. |
+| `scripts/doctor.sh` | Local shell wrapper for the Rust repository doctor. CI invokes the Rust binary directly. |
 
 ## GitHub Configuration
 
 | Path | Purpose |
 | --- | --- |
 | `.github/FUNDING.yml` | Placeholder funding configuration. |
-| `.github/dependabot.yml` | Weekly Dependabot checks for GitHub Actions and Cargo. |
+| `.github/dependabot.yml` | Scheduled and grouped GitHub Actions and Cargo version updates. |
 | `.github/CODEOWNERS` | Default review visibility for repository changes. |
 | `.github/PULL_REQUEST_TEMPLATE.md` | Pull request checklist. |
 | `.github/ISSUE_TEMPLATE/config.yml` | Issue template configuration. |
 | `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug report form. |
 | `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature request form. |
 | `.github/ISSUE_TEMPLATE/documentation_task.yml` | Documentation task form. |
-| `.github/workflows/basic-checks.yml` | Simple repository smoke test. |
+| `.github/workflows/basic-checks.yml` | Protected Rust quality and repository-policy gate with stale-run cancellation, merge-queue support, and manual dispatch. |
 
 ## Current Design Principle
 
-Keep everything small, readable, and beginner-friendly. This repository is for learning GitHub workflows, not for production use.
+Keep the implementation small and readable while making every new safety or automation rule self-enforcing. This repository is for learning GitHub workflows, not for production use.

--- a/src/bin/check_repo.rs
+++ b/src/bin/check_repo.rs
@@ -65,6 +65,26 @@ const SOURCE_REFERENCES: &[(&str, &[&str])] = &[
     ),
     ("Cargo.lock", &["name = \"test-project-tbd\""]),
     (
+        ".github/workflows/basic-checks.yml",
+        &[
+            "merge_group:",
+            "workflow_dispatch:",
+            "cancel-in-progress: true",
+            "cargo clippy --locked --all-targets --all-features -- -D warnings",
+            "cargo test --locked --all-targets --all-features",
+            "cargo run --quiet --locked --bin check_repo",
+        ],
+    ),
+    (
+        ".github/dependabot.yml",
+        &[
+            "routine-actions:",
+            "routine-rust:",
+            "applies-to: \"version-updates\"",
+            "timezone: \"Europe/Lisbon\"",
+        ],
+    ),
+    (
         "src/main.rs",
         &["#![forbid(unsafe_code)]", "GitHub staging lab ready."],
     ),


### PR DESCRIPTION
## Summary

- Cancel stale runs for the same pull request or ref while preserving the required `Repository smoke test` name.
- Run the gate on pull requests, pushes to `main`, merge-queue groups, and manual dispatches.
- Split formatting, strict all-target/all-feature Clippy, locked all-target/all-feature tests, and the Rust repository doctor into direct diagnostic steps.
- Group routine Dependabot minor and patch updates by ecosystem on a fixed Europe/Lisbon schedule while keeping major updates separate.
- Make the repository doctor assert the durable CI and Dependabot policy so future edits cannot silently regress the automation baseline.
- Update the README and workflow/structure documentation to match the actual implementation.

## Verification

- Protected `Repository smoke test` required before merge.
- The changed workflow validates its own pull-request merge commit.
- The repository doctor verifies the new workflow and Dependabot invariants.

## Risk / Notes

- No scripts, dependencies, permissions, or write-capable tokens added.
- The local `scripts/doctor.sh` remains available for developers; CI invokes the Rust binary directly.
- Major dependency updates remain individual pull requests rather than being buried inside routine groups.
