### PR TITLE
Close required-file scan limit bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The doctor verifies that:
 - expected Rust safety and CI-policy references remain in place;
 - issue evidence artifacts are explicitly marked as redacted;
 - repository symlinks cannot silently escape the scan boundary;
+- traversal is iterative and stops after 20,000 visited entries instead of allowing unbounded filesystem work or recursion depth;
+- non-binary text reads, including required-file reference checks, are capped at 4 MiB per file before content is loaded into memory;
 - sensitive filenames, key containers, password-manager databases, and common root credential stores are not committed;
 - private-key blocks, AWS access-key shapes, and provider-specific token shapes are flagged;
 - quoted and unquoted secret assignments are scored using key semantics, length, character classes, and value diversity;
@@ -99,6 +101,7 @@ Dependabot checks GitHub Actions and Cargo every Monday at 06:00 Europe/Lisbon t
 - Rust starter project
 - Modular Rust-native repository doctor and local shell wrapper
 - Scored secret-signal classification and internal precision/recall regression coverage
+- Bounded text reads and iterative repository traversal
 - License and disclaimer hygiene
 - Protected branch, pull-request, merge-queue, and manual quality gates
 - Basic public-repository policy files

--- a/src/bin/check_repo.rs
+++ b/src/bin/check_repo.rs
@@ -211,6 +211,18 @@ fn check_source_references(root: &Path, missing: &mut Vec<String>) {
             continue;
         }
 
+        match fs::metadata(&source_path) {
+            Ok(metadata) if is_oversized_text_file(metadata.len()) => {
+                missing.push(format!("{path} exceeds the 4 MiB text scan limit"));
+                continue;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                missing.push(format!("{path} metadata could not be read: {error}"));
+                continue;
+            }
+        }
+
         let Ok(content) = fs::read_to_string(&source_path) else {
             missing.push(format!("{path} must be readable as UTF-8"));
             continue;


### PR DESCRIPTION
## Summary

- Apply the existing 4 MiB text-read limit to required-file reference checks before they call `read_to_string`.
- Surface metadata failures for required reference files explicitly.
- Document both resource bounds: 4 MiB per non-binary text file and 20,000 visited repository entries.

## Why

The general repository scan was resource-bounded, but `check_source_references` ran first and could still load an oversized required file. That made the limit incomplete. This closes the bypass rather than merely documenting around it.

## Verification

- Protected `Repository smoke test` required before merge.
- The existing exact-boundary test continues to cover the shared size predicate.
- CI runs formatting, strict all-target/all-feature Clippy, locked all-target/all-feature tests, and the doctor itself.

## Risk / Notes

- No new dependency, script, workflow, or permission surface.
- Oversized required configuration/source files now fail before content is loaded, matching the rest of the doctor.
