### PR TITLE
Reconcile resource-bound hardening documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ This project follows a simple chronological changelog. It is a learning reposito
 - Enforced explicit top-level workflow token permissions, rejected
   `pull_request_target`, and required checkout steps to disable persisted
   credentials.
+- Rejected non-binary repository text over 4 MiB before loading content,
+  reported metadata failures explicitly, and applied the same bound to
+  required-file reference checks.
+- Replaced recursive filesystem walking with an iterative traversal capped at
+  20,000 directory entries.
 - Expanded the protected Rust gate to all targets and features, direct doctor
   execution, merge-queue commits, and manual dispatches while canceling stale
   runs for the same pull request or ref.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -39,7 +39,7 @@ This document explains the current repository layout.
 | Path | Purpose |
 | --- | --- |
 | `src/main.rs` | Small Rust starter program. |
-| `src/bin/check_repo.rs` | Repository inventory, required-file policy, sensitive-path checks, and classifier orchestration. |
+| `src/bin/check_repo.rs` | Repository inventory, bounded traversal and text reads, required-file policy, sensitive-path checks, and classifier orchestration. |
 | `src/bin/check_repo/secrets.rs` | Provider signatures and scored secret-assignment classification with precision/recall regression tests. |
 | `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions permission and immutable-reference checks. |
 


### PR DESCRIPTION
## Summary

- Record the 4 MiB text-read ceiling, required-file reference bound, and 20,000-entry iterative traversal in the changelog.
- Update the project structure map so the repository doctor's resource bounds are visible alongside its policy and classifier responsibilities.

## Verification

- Protected `Repository smoke test` required before merge.
- Documentation is scanned by the same repository doctor whose behavior it describes.

## Risk / Notes

- Documentation-only; no scripts, dependencies, workflows, or executable behavior changed.
