### PR TITLE
Refresh policy, support, and evidence documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,44 +1,57 @@
 # Code of Conduct
 
+Status reviewed: **2026-08-16**.
+
 ## Purpose
 
-This repository is a public learning and testing project. The goal is to keep participation simple, respectful, relevant, and safe enough for beginners to learn.
+This is a public learning and testing repository. Participation should remain respectful, relevant, evidence-conscious, and safe enough for beginners and reviewers to work without navigating harassment, data exposure, or deliberate disruption.
+
+## Scope
+
+This Code of Conduct applies to repository issues, pull requests, reviews, discussions, comments, release notes, evidence assets, and other interactions connected to this project.
 
 ## Expected Behavior
 
 Participants are expected to:
 
-- communicate respectfully and constructively;
-- keep discussions relevant to this repository;
-- avoid harassment, abuse, threats, discrimination, or personal attacks;
-- avoid posting secrets, credentials, private information, confidential material, or personal data;
-- respect the repository's learning-focused purpose and public-use boundaries.
+- communicate respectfully, directly, and constructively;
+- keep contributions relevant to the repository;
+- criticize code, decisions, evidence, and proposals rather than attacking people;
+- disclose uncertainty and limitations honestly;
+- protect secrets, credentials, personal data, confidential information, and unredacted evidence;
+- respect the repository's learning-focused purpose and no-support boundaries;
+- follow the contribution, security, and evidence-handling rules.
 
 ## Unacceptable Behavior
 
 Unacceptable behavior includes, without limitation:
 
-- harassment, intimidation, abuse, or threats;
-- discriminatory, hateful, sexually explicit, or violent content;
-- spam, trolling, impersonation, or disruptive conduct;
-- publishing private information without permission;
-- submitting malware, exploit payloads, secrets, credentials, or harmful material;
-- using issues, pull requests, discussions, or comments for unrelated promotion or support demands.
+- harassment, intimidation, abuse, threats, discrimination, or personal attacks;
+- hateful, sexually explicit, violent, or targeted degrading content;
+- spam, trolling, impersonation, manipulation, or deliberate disruption;
+- publishing another person's private information without permission;
+- submitting malware, harmful exploit payloads, credentials, secrets, or deliberately unsafe material;
+- uploading unredacted screenshots, logs, exports, recordings, or release assets;
+- using issues, pull requests, discussions, comments, or release pages for unrelated promotion or support demands;
+- misrepresenting evidence bundles as supported software releases;
+- repeatedly ignoring repository safety or scope instructions after correction.
 
 ## Enforcement
 
-The repository owner may moderate, edit, hide, delete, lock, or close issues, pull requests, comments, discussions, or other contributions at their discretion.
+The repository owner may edit, hide, delete, lock, close, revert, or reject issues, pull requests, comments, discussions, releases, assets, or other contributions at their discretion.
 
-The repository owner may also block users, report abuse, or take other reasonable steps to protect the repository and its participants.
+The repository owner may also block users, report abuse, remove access, or take other reasonable steps to protect the repository, its participants, and affected third parties.
 
-## No Support Obligation
+Enforcement decisions may consider severity, repetition, intent, impact, safety, and the repository's limited maintenance capacity.
 
-This Code of Conduct does not create any duty to provide support, maintenance, review, response, mediation, investigation, or enforcement. For support boundaries, see [SUPPORT.md](SUPPORT.md).
+## No Support or Investigation Obligation
+
+This Code of Conduct does not create a duty to provide support, mediation, investigation, response, appeal, maintenance, or enforcement on any timeline.
 
 ## Related Documents
 
-- [LICENSE](LICENSE)
-- [DISCLAIMER.md](DISCLAIMER.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
 - [SECURITY.md](SECURITY.md)
 - [SUPPORT.md](SUPPORT.md)
-- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [DISCLAIMER.md](DISCLAIMER.md)
+- [LICENSE](LICENSE)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,106 @@
 # Contributing
 
+Status reviewed: **2026-08-16**.
+
 ## Project Status
 
-This repository is a personal learning and testing project. Contributions are not guaranteed to be reviewed, accepted, merged, maintained, supported, or responded to.
-
-The public GitHub contributors list may show accounts that authored or co-authored commits. That list is public and controlled by GitHub's commit attribution rules.
+This repository is a personal learning and testing project. Contributions are welcome for consideration, but they are not guaranteed to be reviewed, accepted, merged, maintained, supported, credited beyond GitHub's normal attribution, or answered.
 
 ## Before Contributing
 
 By opening an issue, pull request, discussion, comment, or other contribution, you confirm that:
 
-- your contribution is your own work or you have the right to submit it;
-- your contribution does not contain secrets, credentials, private keys, tokens, passwords, personal data, confidential information, or third-party material you are not authorized to share;
-- your contribution may be modified, rejected, closed, deleted, or ignored at the author's discretion; and
-- your contribution is submitted under the same Apache License 2.0 terms that apply to this repository, unless clearly stated otherwise in writing.
+- the contribution is your own work or you have the right to submit it;
+- it does not contain secrets, credentials, private keys, tokens, passwords, personal data, customer data, confidential information, regulated information, or third-party material you are not authorized to share;
+- any evidence artifact has been reviewed and explicitly redacted before publication;
+- the contribution may be modified, rejected, closed, deleted, or ignored at the repository owner's discretion;
+- the contribution is submitted under the same Apache License 2.0 terms that apply to this repository unless clearly agreed otherwise in writing.
+
+## Use a Branch and Pull Request
+
+Do not submit routine work directly to protected `main`.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c contribution/describe-the-change
+```
+
+Keep one coherent change per branch. Review the diff before staging and avoid unrelated formatting, generated files, backups, or drive-by rewrites.
+
+## Required Local Validation
+
+For code, workflow, configuration, or doctor-policy changes, run:
+
+```bash
+cargo fmt --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-targets --all-features
+cargo run --quiet --locked --bin check_repo
+```
+
+For documentation-only changes, the Rust commands still provide the authoritative repository gate because the doctor validates required documentation and policy invariants. At minimum, review:
+
+```bash
+git diff --check
+git diff
+bash scripts/doctor.sh
+```
+
+The protected `Repository smoke test` remains the final merge requirement.
+
+## Pull Request Requirements
+
+A pull request should state:
+
+- what changed;
+- why it changed;
+- how it was verified;
+- security, privacy, data, compatibility, and operational impact;
+- documentation impact;
+- deliberate exclusions, limitations, or follow-up work.
+
+Update current-state documentation in the same pull request when behavior, commands, architecture, file layout, policies, automation, supported tooling, roadmap status, or evidence handling changes.
 
 ## No Sensitive Information
 
 Do not submit:
 
-- API keys, tokens, passwords, private keys, or credentials;
-- personal data or confidential information;
-- customer data or production data;
-- exploit payloads against third-party systems;
+- API keys, access tokens, passwords, private keys, or credentials;
+- live `.env` files, root credential stores, key containers, or password databases;
+- personal, customer, confidential, regulated, or production data;
+- harmful third-party exploit payloads;
+- unredacted screenshots, logs, recordings, exports, or evidence bundles;
 - material that violates another person's rights or applicable law.
 
-The repository doctor runs in CI and rejects common secret patterns, private-key blocks, sensitive filenames such as `.env`, and evidence artifacts that are not explicitly marked as redacted.
+The doctor catches common patterns and paths, not every possible disclosure. Passing automation is not permission to publish material you have not reviewed.
 
-## Pull Requests and Issues
+## Evidence and GitHub Releases
 
-Pull requests and issues should be simple, relevant, and limited to this learning repository. There is no guaranteed review timeline, merge timeline, support obligation, or maintenance commitment.
+In-tree evidence must live under an explicitly redacted path. GitHub Release assets are outside the checked-out repository tree and are not inspected by the local doctor.
 
-For additional terms, see [DISCLAIMER.md](DISCLAIMER.md), [SECURITY.md](SECURITY.md), [SUPPORT.md](SUPPORT.md), and [LICENSE](LICENSE).
+Before publishing or changing a release-asset bundle:
+
+1. Review every asset manually.
+2. Remove account identifiers, credentials, private data, and unrelated information.
+3. Use a tag and release name that identifies the external issue and states that the assets are evidence.
+4. Do not present an evidence tag as a software version or supported release.
+
+## Scope and Design
+
+Prefer changes that are:
+
+- focused and reversible;
+- dependency-free unless a dependency has clear measured value;
+- consistent with the Rust-first design;
+- deterministic and resource-bounded;
+- accompanied by regression coverage when behavior changes;
+- honest about internal metrics and external limitations.
+
+The repository does not need more scaffolding merely because scaffolding can be generated. Civilization has suffered enough YAML already.
+
+## Review and Maintenance Boundaries
+
+There is no guaranteed review, response, merge, fix, release, support, or maintenance timeline. A contribution does not create an obligation or commercial relationship.
+
+For related terms, see [DISCLAIMER.md](DISCLAIMER.md), [SECURITY.md](SECURITY.md), [SUPPORT.md](SUPPORT.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [LICENSE](LICENSE).

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,62 +1,99 @@
 # Disclaimer
 
+Status reviewed: **2026-08-16**.
+
 ## Important Notice
 
-This repository is a personal learning, testing, and experimentation project. It is not a production system, commercial product, professional service, managed service, security tool, legal document, compliance framework, or operational recommendation.
+This repository is a personal learning, testing, and experimentation project. It is not a production system, commercial product, managed service, security product, compliance framework, professional service, or operational recommendation.
 
-By accessing, copying, modifying, distributing, running, relying on, or otherwise using any part of this repository, you do so voluntarily and entirely at your own risk.
-
-If you do not agree with these terms, do not use, copy, modify, distribute, run, rely on, or otherwise interact with this repository or its contents.
+Any access, copying, modification, distribution, execution, adaptation, publication, or reliance is voluntary and entirely at the user's own risk.
 
 ## No Warranty
 
-This repository and all files, code, documentation, examples, configurations, comments, workflows, and related materials are provided on an "as is" and "as available" basis, without warranties, representations, guarantees, promises, or conditions of any kind, whether express, implied, statutory, or otherwise.
+The repository and all code, documentation, examples, configurations, comments, workflows, tests, issue forms, release notes, tags, and evidence assets are provided on an "as is" and "as available" basis, without warranties, representations, guarantees, promises, or conditions of any kind.
 
-Without limitation, no warranty is given that this repository or its contents are accurate, complete, secure, error-free, uninterrupted, maintained, suitable for any particular purpose, fit for production use, compatible with any system, compliant with any law or regulation, or free from defects, vulnerabilities, harmful components, or data-loss risks.
+No warranty is given that any material is:
 
-The author does not warrant that any issue, pull request, discussion, comment, recommendation, example, or suggested change is correct, safe, complete, current, or appropriate for your circumstances.
+- accurate, complete, current, secure, or error-free;
+- maintained, supported, compatible, or continuously available;
+- suitable for a particular purpose or environment;
+- fit for production, enterprise, regulated, safety-critical, privacy-sensitive, or security-sensitive use;
+- compliant with any law, regulation, policy, contract, license, or standard;
+- free from defects, vulnerabilities, harmful components, false positives, false negatives, or data-loss risk.
+
+## Automated Checks and Metrics
+
+A passing `Repository smoke test`, repository-doctor result, unit test, lint result, or formatting check means only that the checked revision satisfied the implemented rules at that time.
+
+It does not constitute:
+
+- a security audit or penetration test;
+- production certification;
+- legal or regulatory compliance;
+- vulnerability-free status;
+- complete secret detection;
+- support, warranty, or maintenance;
+- validation of Git history, forks, release assets, external services, repository settings, or deployment environments.
+
+The classifier's average-precision floor of `0.95` applies only to the repository's internal labeled regression corpus. It is not a claim about external production performance, generalization, or fitness for secret scanning in another repository.
 
 ## No Professional Advice
 
-Nothing in this repository constitutes legal, financial, security, engineering, compliance, business, medical, or other professional advice. Any material in this repository is provided only for general learning and experimentation. You are solely responsible for obtaining appropriate professional advice before relying on, adapting, or deploying anything from this repository.
+Nothing in this repository constitutes legal, financial, security, engineering, compliance, business, medical, or other professional advice. Repository material is provided only for general learning and experimentation.
 
-## No Production Use Representation
+Users are responsible for obtaining appropriate advice before relying on, adapting, publishing, or deploying anything.
 
-This repository is not represented as ready or safe for production, enterprise, commercial, regulated, safety-critical, security-sensitive, or privacy-sensitive use. Do not use this repository with live systems, confidential information, credentials, personal data, customer data, production infrastructure, or business-critical workflows unless you have independently reviewed, tested, secured, and validated it.
+## No Production-Use Representation
+
+The repository is not represented as ready or safe for live systems. Do not use it with:
+
+- credentials, access tokens, private keys, or secrets;
+- personal, customer, confidential, regulated, or production data;
+- production infrastructure or business-critical workflows;
+- systems where defects, downtime, incorrect detection, data exposure, or data loss could cause harm.
 
 ## User Responsibility
 
-You are solely responsible for:
+Users are solely responsible for:
 
-- reviewing, testing, validating, and securing anything you use from this repository;
-- ensuring compatibility with your systems, tools, dependencies, and workflows;
-- complying with all applicable laws, regulations, policies, licenses, contracts, and third-party rights;
-- protecting your own data, credentials, devices, accounts, infrastructure, and users;
-- making appropriate backups and recovery plans before use; and
-- determining whether this repository or any part of it is suitable for your intended purpose.
+- reviewing, testing, validating, securing, and adapting repository material;
+- determining compatibility with their systems, tools, dependencies, workflows, and risk tolerance;
+- complying with applicable laws, regulations, contracts, licenses, policies, and third-party rights;
+- protecting data, credentials, accounts, devices, infrastructure, and users;
+- maintaining backups, recovery plans, monitoring, and incident-response procedures;
+- rotating or revoking exposed credentials and assessing downstream impact;
+- reviewing screenshots, logs, exports, and other evidence before publication.
 
-You are also solely responsible for removing, rotating, revoking, or remediating any secret, credential, token, key, data, or other sensitive material that you expose through your own use, fork, clone, issue, pull request, discussion, or other communication.
+## Tags, Releases, and Evidence Assets
+
+The tags `codex-issue-22773-assets` and `codex-issue-23192-assets` identify evidence-asset bundles for external issue reports. They are not supported software releases, versioned products, stable builds, or compatibility statements.
+
+GitHub Release assets are outside the checked-out repository tree and are not automatically inspected by the local repository doctor. Publication of an asset does not guarantee complete redaction, accuracy, continued availability, or suitability for reuse.
 
 ## Security Notice
 
-This repository may contain incomplete, experimental, outdated, insecure, placeholder, or intentionally simplified material. It may not follow security best practices. It must not be treated as reviewed, audited, hardened, supported, or vulnerability-free.
+The repository may contain incomplete, experimental, outdated, insecure, placeholder, or intentionally simplified material. It must not be treated as audited, hardened, supported, or vulnerability-free.
 
-Never commit secrets, passwords, tokens, API keys, private keys, personal data, confidential information, or production credentials to this repository or to any fork, issue, pull request, discussion, or related communication.
+Never publish secrets, credentials, private information, confidential material, or unredacted evidence in this repository, a fork, issue, pull request, discussion, comment, release, or related communication.
 
 ## Third-Party Material
 
-This repository may reference or interact with third-party software, services, libraries, websites, platforms, tools, or documentation. The author does not control and is not responsible for any third-party material, behavior, availability, security, terms, policies, licenses, or consequences arising from their use.
+The repository may reference or interact with third-party software, services, libraries, websites, platforms, tools, issue trackers, or documentation. The author does not control and is not responsible for third-party behavior, availability, security, terms, policies, licenses, changes, or consequences.
 
 ## No Support or Maintenance Obligation
 
-The author has no obligation to provide support, updates, fixes, patches, maintenance, monitoring, review, response, compatibility updates, security updates, or continued availability. Issues, pull requests, questions, reports, or requests may be ignored, closed, modified, or deleted at the author's discretion.
+The author has no obligation to provide support, review, updates, fixes, patches, maintenance, monitoring, security response, compatibility work, continued availability, or any response timeline.
+
+Issues, pull requests, discussions, reports, and requests may be ignored, closed, changed, locked, or deleted at the author's discretion.
 
 ## Limitation of Liability
 
-To the maximum extent permitted by applicable law, the author shall not be liable for any claim, damage, loss, liability, cost, expense, or consequence of any kind arising from or related to this repository or its contents, whether direct, indirect, incidental, special, consequential, exemplary, punitive, or otherwise.
+To the maximum extent permitted by applicable law, the author shall not be liable for any claim, damage, loss, liability, cost, expense, or consequence arising from or related to the repository or its contents, whether direct, indirect, incidental, special, consequential, exemplary, punitive, or otherwise.
 
-This includes, without limitation, loss of profits, revenue, business, opportunity, goodwill, data, files, credentials, systems, access, privacy, security, reputation, or service availability; business interruption; device, account, infrastructure, or software damage; security incidents; compliance issues; legal exposure; or reliance on any material in this repository.
+This includes loss of profits, revenue, business, opportunity, goodwill, data, files, credentials, systems, access, privacy, security, reputation, or service availability; business interruption; device, account, infrastructure, or software damage; security incidents; compliance issues; legal exposure; or reliance on repository material.
 
 ## License Relationship
 
-This disclaimer supplements and clarifies the risk allocation already reflected in the [Apache License 2.0](LICENSE). It does not replace the Apache License 2.0. See [LEGAL_NOTICES.md](LEGAL_NOTICES.md) for plain-language context. If there is any conflict between this disclaimer and the Apache License 2.0, the Apache License 2.0 controls to the extent required by applicable law.
+This disclaimer supplements and clarifies the risk allocation reflected in the [Apache License 2.0](LICENSE). It does not replace the license. See [LEGAL_NOTICES.md](LEGAL_NOTICES.md) for plain-language context.
+
+If this disclaimer conflicts with the Apache License 2.0, the license controls to the extent required by applicable law.

--- a/LEGAL_NOTICES.md
+++ b/LEGAL_NOTICES.md
@@ -1,75 +1,82 @@
 # Legal Notices
 
-This file gives plain-language context for the repository's license, disclaimers, and public-use boundaries.
+Status reviewed: **2026-08-16**.
 
-It is not legal advice. If you need legal advice, ask a qualified lawyer.
+This file provides plain-language context for the repository's license, disclaimers, public-use boundaries, evidence-asset tags, and funding status. It is not legal advice.
 
-## License Summary
+## Controlling License
 
 This repository uses the [Apache License 2.0](LICENSE).
 
-Apache-2.0 is a permissive open-source license. In general, it allows use, copying, modification, distribution, and sublicensing, subject to the license conditions.
+Apache-2.0 is a permissive open-source license that generally allows use, copying, modification, distribution, and sublicensing subject to its conditions. It also contains patent-license language, redistribution requirements, warranty disclaimers, and liability limitations.
 
-Apache-2.0 includes explicit patent-license language and detailed redistribution conditions. It also says the work is provided on an "as is" basis and limits liability.
+The standard `LICENSE` text controls. This file explains repository context but does not rewrite or replace the license.
 
-The `NOTICE` file contains this repository's current copyright and attribution notice.
+## Copyright and Attribution
 
-## Why the License Text Is Not Rewritten
+The repository's current copyright and attribution statement appears in [NOTICE](NOTICE).
 
-The `LICENSE` file intentionally uses the standard Apache License 2.0 text.
+The appendix at the end of the standard Apache License contains generic instructions, including a placeholder such as `Copyright [yyyy] [name of copyright owner]`. That placeholder is part of the standard license text and is not this repository's attribution notice.
 
-Changing standard license language can create ambiguity. Extra context belongs in separate files such as this one, [DISCLAIMER.md](DISCLAIMER.md), [SECURITY.md](SECURITY.md), [SUPPORT.md](SUPPORT.md), [CONTRIBUTING.md](CONTRIBUTING.md), and [SPONSORS.md](SPONSORS.md).
+## Why the Standard License Is Unmodified
 
-The appendix at the bottom of the Apache License is generic instruction text from the official license. The placeholder line `Copyright [yyyy] [name of copyright owner]` is not your repository's copyright notice. For this repository, use [NOTICE](NOTICE).
+Changing standard license language can create ambiguity and interfere with automated license detection. Repository-specific context therefore remains in separate files:
 
-The `LICENSE` file is kept as the standard Apache License 2.0 text so GitHub can correctly detect the license.
+- [NOTICE](NOTICE);
+- [DISCLAIMER.md](DISCLAIMER.md);
+- [SECURITY.md](SECURITY.md);
+- [SUPPORT.md](SUPPORT.md);
+- [CONTRIBUTING.md](CONTRIBUTING.md);
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md);
+- [SPONSORS.md](SPONSORS.md).
 
 ## Public Repository Boundaries
 
-This repository is public, but public does not mean:
+Public availability does not mean that the repository is:
 
 - production-ready;
-- secure;
-- audited;
-- supported;
-- maintained on request;
-- suitable for sensitive data;
+- secure, audited, or vulnerability-free;
+- supported or maintained on request;
+- suitable for credentials, personal data, confidential information, or regulated data;
 - professional advice;
-- a service, product, or warranty.
+- a commercial service or product;
+- covered by a warranty, service level, compatibility promise, or maintenance commitment.
 
-Use this repository only for learning, testing, and experimentation unless you independently review, test, secure, and validate anything you use.
+Use, adapt, or deploy repository material only after independent review, testing, validation, and hardening appropriate to the intended context.
 
-## Sponsorship Boundaries
+## Package and Release Status
 
-Any sponsorship, donation, tip, funding, or financial contribution connected to this repository is voluntary and does not create a support, maintenance, consulting, service-level, feature, priority, warranty, partnership, agency, or commercial obligation.
+The Rust package is marked `publish = false`. Package version `0.1.0` is a repository development identifier, not a supported public distribution.
 
-See [SPONSORS.md](SPONSORS.md) for the temporary sponsorship notice.
+The tags `codex-issue-22773-assets` and `codex-issue-23192-assets` identify public redacted evidence bundles for external Codex issue reports. They are not software releases, semantic versions, stable builds, supported packages, or compatibility commitments.
+
+## Funding Status
+
+No active GitHub funding provider is configured as of 2026-08-16. The placeholder `.github/FUNDING.yml` does not create sponsorship tiers, paid support, consulting, service-level obligations, feature commitments, priority, warranty, partnership, agency, or commercial rights.
+
+See [SPONSORS.md](SPONSORS.md) for the current status.
 
 ## No Sensitive Information
 
-Do not submit, upload, commit, paste, or share:
+Do not submit, upload, commit, paste, publish, or attach:
 
-- passwords;
-- API keys;
-- tokens;
-- private keys;
-- `.env` files;
-- personal data;
-- customer data;
-- confidential information;
-- regulated data;
-- production credentials.
+- passwords, API keys, tokens, private keys, or credentials;
+- live `.env` files or credential stores;
+- personal, customer, confidential, regulated, or production data;
+- unredacted screenshots, recordings, logs, exports, or evidence assets;
+- third-party material you are not authorized to share.
 
-If sensitive information is exposed, rotating or revoking the affected secret is usually more important than simply deleting the file.
+If sensitive information is exposed, revoke or rotate the affected credential immediately. Deleting one file, commit, tag, release, or asset does not guarantee that copies, caches, forks, downloads, or indexes have disappeared.
 
-## Relationship to Other Files
+## Relationship to Other Documents
 
-- [LICENSE](LICENSE) contains the actual open-source license.
-- [NOTICE](NOTICE) contains the repository copyright and attribution notice.
-- [DISCLAIMER.md](DISCLAIMER.md) explains warranty, liability, reliance, and use-at-your-own-risk boundaries.
-- [SECURITY.md](SECURITY.md) explains security expectations and unsupported status.
-- [SUPPORT.md](SUPPORT.md) explains that there is no formal support or maintenance promise.
-- [CONTRIBUTING.md](CONTRIBUTING.md) explains contribution boundaries.
-- [SPONSORS.md](SPONSORS.md) explains temporary sponsorship boundaries.
+- [LICENSE](LICENSE) contains the controlling open-source license.
+- [NOTICE](NOTICE) contains repository copyright and attribution.
+- [DISCLAIMER.md](DISCLAIMER.md) explains warranty, liability, reliance, and risk boundaries.
+- [SECURITY.md](SECURITY.md) explains current guardrails, coverage limits, and unsupported status.
+- [SUPPORT.md](SUPPORT.md) explains the absence of formal support and maintenance obligations.
+- [CONTRIBUTING.md](CONTRIBUTING.md) explains current contribution and evidence-handling requirements.
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) explains participation and moderation expectations.
+- [SPONSORS.md](SPONSORS.md) explains current funding and sponsorship boundaries.
 
-If there is a conflict between informal explanation and the Apache License 2.0, the Apache License 2.0 controls to the extent required by applicable law.
+If an informal explanation conflicts with the Apache License 2.0, the license controls to the extent required by applicable law.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,6 @@
-Staging Lab
+Rust Staging Lab
 Copyright 2026 Jean-Claude Joanna
 
-This repository is a personal learning and staging project for now.
+This repository is a personal Rust-first learning, testing, and staging project.
+
+The tags codex-issue-22773-assets and codex-issue-23192-assets identify public evidence-asset bundles, not software releases.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ Dependabot checks GitHub Actions and Cargo every Monday at **06:00 Europe/Lisbon
 
 Routine minor and patch updates are grouped by ecosystem. Major updates remain separate for explicit review. Open version-update pull requests are capped per ecosystem.
 
+## Evidence Asset Releases
+
+The repository currently has two GitHub Release tags:
+
+- `codex-issue-22773-assets`, published 2026-05-15;
+- `codex-issue-23192-assets`, published 2026-05-17.
+
+They are public redacted screenshot bundles supporting external Codex issue reports. They are **not software releases**, package versions, supported distributions, production builds, or compatibility promises. The tags point to evidence snapshots and must not be interpreted as semantic-version releases of `test-project-tbd`.
+
+Evidence stored in the repository tree remains subject to the explicit-redaction naming checks under `issue-evidence/`. Release assets are outside the checked-out file tree and must be reviewed separately before publication.
+
 ## Working With the Repository
 
 Start with [START_HERE.md](START_HERE.md) for the beginner map. The current operational guides are:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,42 +1,95 @@
 # Security Policy
 
+Status reviewed: **2026-08-16**.
+
 ## Project Status
 
-This is a personal learning and testing repository. It is not a production system, security product, audited codebase, maintained service, or hardened project.
+This is a public personal learning and testing repository. It is not a production system, supported security product, audited codebase, managed service, secret-management system, or hardened deployment.
 
-## Supported Versions
+The package is marked `publish = false` and is not distributed as a supported Rust crate.
 
-No versions of this repository are formally supported.
+## Supported Versions and Tags
 
-| Version | Supported |
+No branch, commit, package version, tag, release, fork, artifact, or file receives formal security support.
+
+| Surface | Current status |
 | --- | --- |
-| Any version, branch, fork, commit, or file | No formal support |
+| Protected `main` | Active development branch; no formal support |
+| Package version `0.1.0` | Learning version; unpublished and unsupported |
+| `codex-issue-22773-assets` | Evidence-asset tag, not a software release |
+| `codex-issue-23192-assets` | Evidence-asset tag, not a software release |
+| Forks and historical commits | Unsupported |
+
+The two GitHub Releases contain public redacted evidence for external Codex issue reports. They do not represent supported software versions, stable builds, or compatibility commitments.
+
+## Current Guardrails
+
+The repository doctor and protected `Repository smoke test` currently enforce or verify:
+
+- required repository, source, policy, documentation, workflow, and automation invariants;
+- Rust formatting, strict all-target/all-feature Clippy, and locked all-target/all-feature tests;
+- forbidden unsafe Rust;
+- one deterministic repository inventory;
+- iterative traversal capped at 20,000 visited entries;
+- rejection of repository symlinks;
+- a 4 MiB limit on non-binary text reads, including required-file reference checks;
+- explicit failures for unreadable directories, entries, metadata, and files;
+- sensitive filenames, root credential stores, key containers, password-manager databases, and live environment files;
+- private-key blocks, AWS access-key shapes, provider token shapes, and scored generic secret assignments;
+- placeholder, environment-reference, redaction, and low-entropy suppression;
+- explicitly redacted names for in-tree evidence artifacts;
+- explicit top-level workflow permissions;
+- rejection of `write-all`, `contents: write`, and `pull_request_target`;
+- disabled checkout credential persistence;
+- full commit-SHA pins for third-party GitHub Actions;
+- SHA-256 digests for Docker actions;
+- protected workflow and Dependabot configuration invariants.
+
+These controls are guardrails only. They are not proof that the repository is secure, vulnerability-free, complete, correctly configured on every platform, or suitable for sensitive use.
+
+## Coverage Boundaries
+
+The repository doctor inspects the current checked-out filesystem tree. It does not automatically inspect:
+
+- Git history or deleted commits;
+- forks or external clones;
+- GitHub Release assets;
+- external services, accounts, or deployment environments;
+- live repository settings that are not represented by checked files;
+- secrets already copied, cached, indexed, downloaded, or exposed elsewhere;
+- every possible credential format, obfuscation, encoding, or vulnerability class.
+
+Release assets require separate review before publication because they are not present in the checked-out repository tree.
 
 ## Security Expectations
 
-Do not treat anything in this repository as secure, reviewed, production-ready, or suitable for sensitive environments.
-
-Before using any content from this repository, you are responsible for independently reviewing, testing, validating, hardening, and securing it.
-
-The repository doctor and GitHub Actions smoke test reject common secret patterns, private-key blocks, sensitive filenames, unsafe Rust code, non-redacted evidence artifact names, broad workflow write permissions, and GitHub Actions that are not pinned to full commit SHAs. These checks are guardrails only; they are not a security audit, scanner warranty, or substitute for manual review.
-
 Do not use this repository with:
 
-- production credentials;
-- private keys, API keys, tokens, passwords, or secrets;
-- personal data or confidential information;
-- customer data;
-- business-critical workflows;
-- regulated, safety-critical, or security-sensitive systems.
+- production credentials, passwords, keys, tokens, or secrets;
+- personal, customer, confidential, regulated, or production data;
+- business-critical, safety-critical, privacy-sensitive, or security-sensitive systems;
+- any environment where failure, incorrect detection, false reassurance, or data exposure could cause harm.
 
-## Reporting Security Issues
+Review, test, validate, and harden anything independently before use.
 
-Because this is a learning repository with no formal support obligation, there is no guaranteed response time, remediation timeline, or maintenance commitment.
+## Reporting a Security Issue
 
-If you choose to report a security issue, do not include secrets, credentials, private data, exploit payloads against third-party systems, or information that could harm others.
+Never include a live secret, private key, credential, personal data, confidential material, or harmful third-party exploit payload in a public issue, pull request, discussion, comment, or screenshot.
 
-If you accidentally expose a secret, token, password, private key, or credential, revoke or rotate it immediately. Deleting a file or commit is not always enough once information has been pushed to a public repository.
+If GitHub presents a private vulnerability-reporting interface for this repository, prefer it for non-public vulnerability details. Otherwise, open a minimal public issue that identifies the affected file or control without publishing sensitive proof, active credentials, or harmful exploitation details.
+
+There is no guaranteed response time, remediation deadline, disclosure process, maintenance commitment, or support obligation.
+
+## Accidental Secret Exposure
+
+If a credential or secret is exposed:
+
+1. Revoke or rotate it immediately.
+2. Review access logs and downstream use where available.
+3. Remove the material from the current branch and related public surfaces.
+4. Assess whether Git history, release assets, caches, forks, downloads, or indexes still contain it.
+5. Do not assume deletion of one file or commit has invalidated the exposed value.
 
 ## No Security Warranty
 
-This repository is provided "as is" and may contain incomplete, outdated, insecure, vulnerable, placeholder, or experimental material. See [DISCLAIMER.md](DISCLAIMER.md) and [LICENSE](LICENSE) for the applicable disclaimer and license terms.
+This repository is provided "as is" and may contain incomplete, outdated, insecure, vulnerable, placeholder, experimental, or intentionally simplified material. See [DISCLAIMER.md](DISCLAIMER.md), [SUPPORT.md](SUPPORT.md), and [LICENSE](LICENSE).

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,31 +1,52 @@
-# Sponsors
+# Funding and Sponsorship Status
 
-## Funding Status Notice
+Status reviewed: **2026-08-16**.
 
-This repository does not currently expose active GitHub funding links.
+## Current Funding Status
 
-A placeholder `.github/FUNDING.yml` exists for future funding metadata only. Do not treat sponsorship as available unless GitHub shows an active Sponsor button.
+No active GitHub funding provider is configured for this repository. The placeholder `.github/FUNDING.yml` does not currently expose a Sponsor button or active funding link.
 
-At this stage, this repository does not offer sponsorship tiers, paid support, consulting, service-level commitments, private maintenance, guaranteed responses, feature commitments, commercial deliverables, or any other benefit in exchange for sponsorship or financial support.
+Do not treat sponsorship, paid support, donations, or commercial services as available unless the repository is explicitly updated and GitHub displays an active provider.
 
-Any sponsorship, donation, tip, funding, or financial contribution connected to this repository is voluntary and does not create any contract, partnership, employment relationship, agency relationship, fiduciary duty, support obligation, maintenance obligation, warranty, guarantee, priority entitlement, or right to influence the repository.
+## No Sponsorship Benefits
 
-## No Purchase, Service, or Consideration
+This repository currently offers no:
 
-Sponsorship or financial support is not required to access, use, copy, fork, modify, distribute, or contribute to this repository under the applicable license terms.
+- sponsorship tiers;
+- paid support or consulting;
+- service-level commitments;
+- private maintenance;
+- guaranteed responses or review;
+- feature commitments or roadmap influence;
+- security review or production certification;
+- commercial deliverables;
+- access, priority, warranty, or exclusivity benefits.
 
-Financial support does not purchase software, services, advice, support, access, priority, fixes, updates, features, security review, consulting, or any commercial deliverable.
+Any sponsorship, donation, tip, funding, or financial contribution associated with this repository is voluntary and does not create a contract, purchase, partnership, employment relationship, agency relationship, fiduciary duty, support obligation, maintenance obligation, warranty, guarantee, priority entitlement, or right to influence the project.
+
+## No Purchase or Service
+
+Financial support is not required to access, use, copy, fork, modify, distribute, or contribute to the repository under the applicable license terms.
+
+Financial support does not purchase software, services, advice, support, access, fixes, updates, features, security work, consulting, compatibility, or any other deliverable.
 
 ## Repository Terms Still Apply
 
-All repository use remains subject to the [Apache License 2.0](LICENSE), [DISCLAIMER.md](DISCLAIMER.md), [SECURITY.md](SECURITY.md), [SUPPORT.md](SUPPORT.md), [CONTRIBUTING.md](CONTRIBUTING.md), and any other applicable repository notices.
+All repository use remains subject to:
 
-This funding notice does not replace or modify the license, disclaimer, security policy, support policy, or contribution rules.
+- [LICENSE](LICENSE);
+- [DISCLAIMER.md](DISCLAIMER.md);
+- [SECURITY.md](SECURITY.md);
+- [SUPPORT.md](SUPPORT.md);
+- [CONTRIBUTING.md](CONTRIBUTING.md);
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+This funding status does not replace or modify those documents.
 
 ## Sensitive Information
 
-Do not include secrets, credentials, private keys, API tokens, passwords, personal data, customer data, confidential information, or regulated information in sponsorship messages, public comments, issues, pull requests, discussions, or related communications.
+Do not include secrets, credentials, private keys, access tokens, passwords, personal data, customer data, confidential information, regulated information, or unredacted evidence in funding messages, comments, issues, pull requests, discussions, or related communications.
 
 ## Future Changes
 
-This funding notice may be updated, removed, or replaced at any time as the repository evolves.
+Funding may be enabled, changed, or removed later. Any future provider, benefit, or obligation must be stated explicitly in the repository at that time. Silence, a placeholder file, or an old reference does not create a current offer. Remarkably, contracts still require more than vibes.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,17 +1,46 @@
 # Support Policy
 
-## No Formal Support
+Status reviewed: **2026-08-16**.
 
-This repository is a personal learning and testing project. No formal support, maintenance, troubleshooting, consulting, monitoring, updates, fixes, or response obligations are provided.
+## Current Support Status
 
-Issues, discussions, pull requests, comments, emails, or other requests may be reviewed, ignored, closed, modified, or deleted at the author's discretion.
+This repository is a personal learning and testing project. It does not provide formal support, maintenance, troubleshooting, consulting, monitoring, updates, fixes, security response, compatibility work, migration assistance, or service-level commitments.
+
+Issues, pull requests, discussions, comments, emails, and other requests may be reviewed, answered, changed, closed, ignored, locked, or deleted at the repository owner's discretion.
+
+## What the Automated Checks Mean
+
+A passing `Repository smoke test` means only that the checked revision satisfied the repository's current formatting, lint, test, and doctor rules at that time.
+
+It does not create:
+
+- a support entitlement;
+- a maintenance promise;
+- a security warranty;
+- a production-readiness statement;
+- a compatibility guarantee;
+- an obligation to investigate a later failure;
+- an obligation to preserve any feature, file, tag, release asset, or behavior.
+
+The repository's two GitHub Release tags are evidence-asset bundles for external issue reports. They are not supported software releases.
 
 ## Use at Your Own Risk
 
-Any use of this repository or its contents is voluntary and at your own risk. You are responsible for reviewing, testing, validating, securing, and adapting anything before use.
+Any use of this repository or its contents is voluntary and at your own risk. You are responsible for reviewing, testing, validating, securing, adapting, backing up, and monitoring anything before and during use.
 
 ## Not for Production Reliance
 
-This repository should not be relied upon for production systems, regulated environments, security-sensitive workflows, personal data, confidential information, customer data, business-critical operations, or any environment where errors, downtime, defects, vulnerabilities, or data loss could cause harm.
+Do not rely on this repository for:
 
-For additional terms, see [DISCLAIMER.md](DISCLAIMER.md) and [LICENSE](LICENSE).
+- production systems or infrastructure;
+- regulated, safety-critical, privacy-sensitive, or security-sensitive environments;
+- personal, customer, confidential, regulated, or production data;
+- credentials, secrets, private keys, or access tokens;
+- business-critical operations or incident response;
+- any workflow where defects, false positives, false negatives, downtime, or data loss could cause harm.
+
+## No Response Timeline
+
+There is no guaranteed review, reply, merge, fix, update, disclosure, or maintenance timeline. Opening an issue or pull request does not create a queue position, contract, priority, or obligation.
+
+For related boundaries, see [DISCLAIMER.md](DISCLAIMER.md), [SECURITY.md](SECURITY.md), [CONTRIBUTING.md](CONTRIBUTING.md), and [LICENSE](LICENSE).

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -8,7 +8,7 @@ This document maps the current repository layout and the responsibility of each 
 
 | Path | Current responsibility |
 | --- | --- |
-| `README.md` | Current project snapshot, architecture, checks, automation, priorities, and boundaries. |
+| `README.md` | Current project snapshot, architecture, checks, automation, priorities, evidence-release status, and boundaries. |
 | `START_HERE.md` | Beginner map and safe first branch-to-PR exercise. |
 | `Cargo.toml` | Package metadata, version `0.1.0`, Edition 2021, Rust `1.85` floor, license, publish setting, and lint policy. |
 | `Cargo.lock` | Locked dependency state for reproducible local and CI commands. |
@@ -71,12 +71,16 @@ CI runs the Rust doctor directly rather than placing a shell wrapper between Git
 
 ## Evidence Artifacts
 
-| Path | Current responsibility |
+| Location | Current responsibility |
 | --- | --- |
-| `issue-evidence/` | Public issue-supporting artifacts that must be explicitly named as redacted. |
-| `issue-evidence/codex-23192-redacted/` | Current redacted evidence set for the referenced Codex issue. |
+| `issue-evidence/` | Public issue-supporting artifacts committed to the repository tree and required to use explicit redaction naming. |
+| `issue-evidence/codex-23192-redacted/` | Current in-tree redacted evidence set for Codex issue 23192. |
+| Release tag `codex-issue-22773-assets` | Redacted screenshot asset bundle published 2026-05-15 for Codex issue 22773. |
+| Release tag `codex-issue-23192-assets` | Redacted screenshot asset bundle published 2026-05-17 for Codex issue 23192. |
 
-The doctor rejects evidence paths that are not explicitly redacted or that use names such as `unredacted` or `nonredacted`.
+The two GitHub Releases are evidence bundles, not software releases or package versions. Their tags must not be interpreted as supported builds or semantic versions of `test-project-tbd`.
+
+The doctor rejects in-tree evidence paths that are not explicitly redacted or that use names such as `unredacted` or `nonredacted`. GitHub Release assets are outside the checked-out repository tree, so their redaction and content must be reviewed before publication rather than assumed to be covered by the local doctor.
 
 ## Generated and Local-Only Areas
 
@@ -95,6 +99,7 @@ The current design is:
 - fail-closed on unreadable or ambiguous repository state;
 - protected by CI;
 - self-enforcing for critical workflow and Dependabot invariants;
-- explicit about the difference between internal regression metrics and external production claims.
+- explicit about the difference between internal regression metrics and external production claims;
+- explicit about the difference between evidence-asset tags and software releases.
 
-Update this file whenever a maintained path is added, removed, renamed, or materially changes responsibility.
+Update this file whenever a maintained path, release-asset bundle, or material responsibility is added, removed, renamed, or changed.


### PR DESCRIPTION
## Summary

- Add a 2026-08-16 review status to the security, support, contribution, conduct, funding, legal, and disclaimer documents.
- Replace partial security descriptions with the implemented workflow, secret-classifier, filesystem, resource-bound, and coverage controls.
- Define the exact contribution workflow and current validation commands.
- Remove vague temporary funding language and state the current inactive-provider status.
- Distinguish the two May 2026 Codex evidence-asset Releases from software versions or supported builds.
- Document that GitHub Release assets sit outside the checked-out tree and therefore require separate redaction review.
- Update README, project structure, and NOTICE to reflect the real evidence surfaces.

## Verification

- Protected `Repository smoke test` required before merge.
- Documentation remains subject to the repository doctor and current source invariants.

## Risk / Notes

- Documentation and NOTICE only.
- No executable code, workflow, dependency, permission, branch-protection, or runtime behavior changed.
