### PR TITLE
Make GitHub contribution templates operational

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,17 +1,15 @@
-# GitHub Sponsors funding configuration.
+# Funding configuration status reviewed 2026-08-16.
 #
-# This file enables GitHub's Sponsor button only when valid funding
-# accounts are configured and available for this repository.
+# No active funding provider is configured for this repository.
+# This placeholder file does not expose a Sponsor button, sponsorship tier,
+# paid support, consulting, maintenance, priority, service-level commitment,
+# feature entitlement, warranty, or commercial offer.
 #
-# Inactive placeholder:
-# - No sponsorship tiers, paid support, consulting, service-level commitments,
-#   or guaranteed benefits are currently offered.
-# - See SPONSORS.md for the funding status notice.
+# See SPONSORS.md for the current funding and sponsorship boundaries.
+# Configure a provider only after the account is active and the repository
+# documentation has been updated in the same pull request.
 
-# No active funding providers are configured right now.
-# Add `github: [jjoanna2-debug]` only after GitHub Sponsors is active.
-
-# Add external funding providers only when ready.
+# github: [jjoanna2-debug]
 # patreon: username
 # open_collective: username
 # ko_fi: username

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report something that appears broken in this learning repository.
+description: Report a reproducible defect in the current repository, doctor, automation, or documentation.
 title: "Bug: "
 labels:
   - bug
@@ -7,46 +7,116 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a possible issue. Do not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
+        Report the smallest reproducible defect. Remove credentials, personal data, confidential information, and unrelated output before submitting. GitHub Release assets are not inspected by the local doctor, so review every attachment manually.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Choose the primary surface where the defect appears.
+      options:
+        - Rust starter
+        - Repository inventory or resource bounds
+        - Secret classifier
+        - GitHub Actions policy classifier
+        - Protected CI workflow
+        - Dependabot configuration
+        - Documentation or policy
+        - In-tree evidence artifacts
+        - GitHub Release evidence assets
+        - Other
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: Briefly describe the issue.
-      placeholder: What seems broken?
+      label: Defect summary
+      description: State what is broken and the observable consequence.
+      placeholder: The current behavior is incorrect because...
     validations:
       required: true
-  - type: textarea
-    id: steps
+
+  - type: input
+    id: revision
     attributes:
-      label: Steps to reproduce
-      description: List the steps that led to the issue.
+      label: Affected revision
+      description: Provide the commit SHA, branch, tag, or pull request where you reproduced the defect.
+      placeholder: main at abc1234, PR #123, or tag name
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant OS, Rust version, Git version, shell, and GitHub Actions context.
       placeholder: |
-        1. Go to ...
-        2. Click ...
-        3. See ...
+        OS:
+        rustc --version:
+        cargo --version:
+        git --version:
+        Local or GitHub Actions:
     validations:
       required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest deterministic sequence that triggers the defect.
+      placeholder: |
+        1. Start from commit...
+        2. Change or add...
+        3. Run...
+        4. Observe...
+    validations:
+      required: true
+
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
-      description: What did you expect to happen?
+      description: State the precise result that should occur.
     validations:
-      required: false
+      required: true
+
   - type: textarea
     id: actual
     attributes:
       label: Actual behavior
-      description: What actually happened?
+      description: State the precise result that occurs instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Paste only the relevant, reviewed output. Redact secrets, paths, account identifiers, private data, and unrelated content.
+      render: shell
     validations:
       required: false
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression status
+      options:
+        - Worked previously
+        - Never worked
+        - Unknown
+    validations:
+      required: true
+
   - type: checkboxes
     id: safety
     attributes:
-      label: Safety checklist
+      label: Submission checks
       options:
-        - label: I did not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
+        - label: I reproduced this against the revision identified above.
           required: true
-        - label: I understand this repository has no formal support or maintenance obligation.
+        - label: I reviewed the issue body, logs, screenshots, and attachments for secrets and private information.
+          required: true
+        - label: I understand that a report does not create a response, fix, support, or maintenance obligation.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Contribution guide
+    url: https://github.com/jjoanna2-debug/test-project-tbd/blob/main/CONTRIBUTING.md
+    about: Read the current branch, validation, evidence, and pull request requirements before contributing.
   - name: Support policy
     url: https://github.com/jjoanna2-debug/test-project-tbd/blob/main/SUPPORT.md
-    about: Read before asking for help or support.
+    about: Review the current no-support and no-maintenance status before requesting assistance.
   - name: Security policy
     url: https://github.com/jjoanna2-debug/test-project-tbd/blob/main/SECURITY.md
-    about: Read before reporting or discussing security issues.
+    about: Review current guardrails, coverage limits, reporting boundaries, and secret-exposure steps.

--- a/.github/ISSUE_TEMPLATE/documentation_task.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_task.yml
@@ -1,5 +1,5 @@
-name: Documentation task
-description: Suggest a small documentation cleanup or learning-note improvement.
+name: Documentation correction
+description: Report stale, inaccurate, missing, contradictory, or unclear repository documentation.
 title: "Docs: "
 labels:
   - documentation
@@ -7,28 +7,68 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for README, guide, policy, or beginner-onboarding improvements. Do not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
-  - type: textarea
-    id: change
+        Use this form when documentation no longer matches the implemented repository, current date, workflow, policy, file layout, release status, or roadmap. Cite the repository source of truth rather than relying on memory dressed as confidence.
+
+  - type: input
+    id: location
     attributes:
-      label: Requested documentation change
-      description: What should be added, removed, clarified, or corrected?
-      placeholder: Describe the documentation improvement.
+      label: Document and location
+      description: Identify the file and heading, line range, or section.
+      placeholder: README.md, Evidence Asset Releases
     validations:
       required: true
+
   - type: textarea
-    id: reason
+    id: current
     attributes:
-      label: Why it helps
-      description: Explain why this makes the repository clearer or easier to use.
+      label: Current text or omission
+      description: Quote the stale or inaccurate statement, or explain what is missing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source
+    attributes:
+      label: Current source of truth
+      description: Point to the implemented file, workflow, package metadata, repository setting, tag, release, commit, or other evidence that establishes the correction.
+      placeholder: Cargo.toml, src/bin/check_repo.rs, .github/workflows/basic-checks.yml, release tag, or commit SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: correction
+    attributes:
+      label: Required correction
+      description: Describe the exact outcome, replacement, deletion, or clarification needed.
+    validations:
+      required: true
+
+  - type: input
+    id: as_of
+    attributes:
+      label: Verified date
+      description: State the date on which the source of truth was checked.
+      placeholder: YYYY-MM-DD
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related documents
+      description: List other files that may repeat or contradict the same stale statement.
+      placeholder: START_HERE.md, ROADMAP.md, SECURITY.md
     validations:
       required: false
+
   - type: checkboxes
     id: checklist
     attributes:
-      label: Checklist
+      label: Submission checks
       options:
-        - label: I checked that this is relevant to this learning repository.
+        - label: I checked the current repository rather than relying only on an older issue, pull request, or memory.
           required: true
-        - label: I did not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
+        - label: I identified related documents that may require the same correction.
+          required: true
+        - label: I did not include secrets, credentials, personal data, confidential information, or unredacted evidence.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest a small improvement for this learning repository.
+description: Propose a focused, testable improvement to the Rust staging lab.
 title: "Feature: "
 labels:
   - enhancement
@@ -7,41 +7,90 @@ body:
   - type: markdown
     attributes:
       value: |
-        Suggest simple, beginner-friendly improvements only. Do not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
+        Start with the problem, not the preferred implementation. The repository favors small, dependency-conscious, measurable changes over framework-shaped enthusiasm.
+
   - type: textarea
-    id: idea
+    id: problem
     attributes:
-      label: Idea
-      description: What would you like to add or improve?
-      placeholder: Describe the idea clearly.
+      label: Problem
+      description: Describe the current limitation, maintenance cost, false positive, false negative, workflow gap, or learning obstacle.
+      placeholder: The current repository cannot or does not...
     validations:
       required: true
-  - type: textarea
-    id: reason
-    attributes:
-      label: Why it helps
-      description: Explain how this helps the repository as a learning project.
-    validations:
-      required: false
+
   - type: dropdown
     id: area
     attributes:
-      label: Area
+      label: Primary area
       options:
-        - Documentation
-        - Beginner onboarding
-        - Repository hygiene
-        - GitHub workflow practice
-        - Starter project/code
+        - Rust starter or future CLI
+        - Repository inventory or resource bounds
+        - Secret classifier and calibration
+        - GitHub Actions policy classifier
+        - Protected CI workflow
+        - Dependabot automation
+        - Documentation or beginner onboarding
+        - Policy, contribution, or evidence handling
         - Other
     validations:
       required: true
-  - type: checkboxes
-    id: safety
+
+  - type: textarea
+    id: proposal
     attributes:
-      label: Safety checklist
+      label: Proposed outcome
+      description: Describe the behavior or result that should exist after implementation.
+      placeholder: After this change, the repository should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable conditions that would make the proposal complete and verifiable.
+      placeholder: |
+        - Given...
+        - When...
+        - Then...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Explain simpler options, configuration-only options, or reasons not to make the change.
+    validations:
+      required: false
+
+  - type: textarea
+    id: measurement
+    attributes:
+      label: Measurement or regression coverage
+      description: State how value and non-regression would be measured, especially for performance or classifier changes.
+      placeholder: Tests, precision/recall cases, timing, memory bound, CI behavior, or another measurable signal.
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and maintenance cost
+      description: Identify dependencies, permissions, compatibility changes, false-positive risk, false-negative risk, or ongoing maintenance.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Proposal checks
       options:
-        - label: I did not include secrets, credentials, tokens, private keys, personal data, customer data, or confidential information.
+        - label: This proposal is relevant to the current repository roadmap or explains why the roadmap should change.
           required: true
-        - label: I understand this suggestion does not create any obligation to implement it.
+        - label: I considered whether the result can be achieved without a new dependency, script, workflow, or configuration layer.
+          required: true
+        - label: I did not include secrets, credentials, personal data, confidential information, or unredacted evidence.
+          required: true
+        - label: I understand that submission does not create an implementation, review, support, or maintenance obligation.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,25 +2,62 @@
 
 ## Summary
 
-Describe what this pull request changes.
+Describe the completed change in concrete terms.
 
-## Type of Change
+## Why
 
-- [ ] Documentation update
-- [ ] Starter project/code change
-- [ ] Policy or repository hygiene update
-- [ ] GitHub workflow change
-- [ ] Other
+Explain the problem, stale behavior, risk, or maintenance cost this pull request addresses.
 
-## Checklist
+## Scope
 
-- [ ] I reviewed my changes before submitting.
-- [ ] I ran `bash scripts/doctor.sh` or checked the GitHub Actions result.
-- [ ] I did not include secrets, credentials, tokens, passwords, private keys, personal data, customer data, or confidential information.
-- [ ] I kept the change relevant to this learning repository.
-- [ ] I updated documentation if needed.
-- [ ] I understand there is no guaranteed review, merge, support, or maintenance obligation.
+List the files or subsystems intentionally changed. State anything deliberately excluded.
 
-## Notes
+## Verification
 
-Add any extra context, screenshots, limitations, or follow-up ideas here.
+Check every command that applies:
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --locked --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --locked --all-targets --all-features`
+- [ ] `cargo run --quiet --locked --bin check_repo`
+- [ ] `git diff --check`
+- [ ] Documentation-only review completed where executable checks are not relevant
+
+Describe any additional test cases, failure-path checks, or manual verification:
+
+## Impact Review
+
+- [ ] No new runtime dependency
+- [ ] No workflow permission increase
+- [ ] No credential, secret, personal-data, confidential-data, or production-data exposure
+- [ ] No unredacted in-tree or GitHub Release evidence asset
+- [ ] No unsupported software-release claim for an evidence tag
+- [ ] Resource bounds remain explicit and enforced
+- [ ] Backward compatibility or intentional breakage is explained
+
+Explain any checked item that does not apply or any impact that needs review:
+
+## Documentation
+
+- [ ] Current-state documentation was updated in this pull request
+- [ ] Review dates remain accurate
+- [ ] README, roadmap, changelog, policy, workflow, and structure references remain consistent
+- [ ] No documentation change was required, with the reason stated below
+
+Documentation note:
+
+## Risks and Rollback
+
+Describe the strongest plausible failure mode and the clean rollback path.
+
+## Follow-Up
+
+List only genuinely deferred work. Do not use this section as a landfill for pieces required to make the current change correct.
+
+## Final Checklist
+
+- [ ] The branch contains one coherent change
+- [ ] The final diff was reviewed, not merely the commit list
+- [ ] Unrelated files and generated artifacts were excluded
+- [ ] The pull request is ready for the protected `Repository smoke test`
+- [ ] I understand that submission does not create a review, merge, support, or maintenance obligation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ All notable changes to this repository are recorded here. The project follows a 
 - Grouped routine Dependabot minor and patch updates by ecosystem on a fixed Europe/Lisbon schedule while leaving major updates isolated for review.
 - Made the repository doctor assert durable CI and Dependabot guarantees so later edits cannot silently remove the automation baseline.
 - Reconciled the roadmap with completed repository, workflow, automation, and doctor phases.
+- Distinguished the `codex-issue-22773-assets` and `codex-issue-23192-assets` evidence bundles from software releases, package versions, supported builds, and compatibility commitments.
+- Reconciled security, support, contribution, conduct, funding, legal, disclaimer, and attribution documents with the implemented repository and evidence surfaces.
+- Replaced the lightweight pull request checklist with scope, verification, impact, documentation, rollback, and follow-up sections.
+- Reworked issue forms to collect affected revisions, reproducible steps, acceptance criteria, measurements, verified dates, evidence handling, and current sources of truth.
+- Added current contribution, support, and security links to the issue chooser.
+- Dated the inactive funding configuration and tied future provider activation to a documentation update.
 
 ### Documentation
 
@@ -57,9 +63,12 @@ All notable changes to this repository are recorded here. The project follows a 
 - Replaced stale “basic check” descriptions with the current modular doctor, protected gate, merge-queue, concurrency, resource-bound, and dependency-automation behavior.
 - Added explicit review dates to current technical and policy documentation.
 - Replaced vague “temporary” and “for now” status wording with dated, testable statements.
+- Documented that GitHub Release assets are outside the checked-out tree and therefore require separate redaction review.
+- Updated the structure map and README to include current evidence tags and their May 2026 publication dates.
 
 ### Notes
 
 - This repository remains experimental and is provided for learning, testing, and GitHub workflow practice.
 - Earlier closed issues may mention the previous static-page starter. The current repository is a Rust-first staging lab with a modular Rust-native repository doctor.
 - The internal average-precision floor is a regression metric for the repository's labeled test corpus, not a claim about external production performance.
+- The two GitHub Release tags are evidence-asset bundles, not software releases.


### PR DESCRIPTION
## Summary

- Replace the lightweight PR checklist with sections for scope, verification, impact, documentation, rollback, and genuinely deferred follow-up.
- Expand bug reports with affected revision, environment, reproducible steps, sanitized diagnostics, and regression status.
- Make feature requests problem-first, measurable, dependency-conscious, and explicit about acceptance criteria and maintenance cost.
- Turn documentation requests into verified corrections with a current source of truth and review date.
- Add contribution, support, and security policy links to the issue chooser.
- Date the inactive funding configuration and remove ambiguous placeholder commentary.
- Record the policy and template reconciliation in the changelog.

## Verification

- Protected `Repository smoke test` required before merge.
- YAML and Markdown remain subject to repository traversal, size, sensitive-content, and required-file checks.

## Risk / Notes

- GitHub forms, templates, funding comments, and changelog only.
- No executable code, CI workflow, dependency, permission, branch-protection, or runtime behavior changed.
