### PR TITLE
Limit evidence-release claims to verified metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this repository are recorded here. The project follows a 
 - Replaced vague “temporary” and “for now” status wording with dated, testable statements.
 - Documented that GitHub Release assets are outside the checked-out tree and therefore require separate redaction review.
 - Updated the structure map and README to include current evidence tags and their May 2026 publication dates.
+- Tightened release-asset wording so redaction is claimed only where release metadata verifies it; the local doctor does not attest assets outside the checked-out tree.
 
 ### Notes
 

--- a/LEGAL_NOTICES.md
+++ b/LEGAL_NOTICES.md
@@ -48,7 +48,9 @@ Use, adapt, or deploy repository material only after independent review, testing
 
 The Rust package is marked `publish = false`. Package version `0.1.0` is a repository development identifier, not a supported public distribution.
 
-The tags `codex-issue-22773-assets` and `codex-issue-23192-assets` identify public redacted evidence bundles for external Codex issue reports. They are not software releases, semantic versions, stable builds, supported packages, or compatibility commitments.
+The `codex-issue-22773-assets` release metadata explicitly identifies redacted screenshots. The `codex-issue-23192-assets` release is public screenshot evidence. Both tags identify evidence bundles for external Codex issue reports, not software releases, semantic versions, stable builds, supported packages, or compatibility commitments.
+
+GitHub Release assets are outside the checked-out repository tree. The local doctor does not inspect or attest to their redaction, so publication still requires separate asset review.
 
 ## Funding Status
 

--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ Routine minor and patch updates are grouped by ecosystem. Major updates remain s
 
 The repository currently has two GitHub Release tags:
 
-- `codex-issue-22773-assets`, published 2026-05-15;
-- `codex-issue-23192-assets`, published 2026-05-17.
+- `codex-issue-22773-assets`, published 2026-05-15 and explicitly described by its release metadata as a redacted screenshot bundle;
+- `codex-issue-23192-assets`, published 2026-05-17 as a public screenshot-evidence bundle.
 
-They are public redacted screenshot bundles supporting external Codex issue reports. They are **not software releases**, package versions, supported distributions, production builds, or compatibility promises. The tags point to evidence snapshots and must not be interpreted as semantic-version releases of `test-project-tbd`.
+They are **not software releases**, package versions, supported distributions, production builds, or compatibility promises. The tags point to evidence snapshots and must not be interpreted as semantic-version releases of `test-project-tbd`.
 
-Evidence stored in the repository tree remains subject to the explicit-redaction naming checks under `issue-evidence/`. Release assets are outside the checked-out file tree and must be reviewed separately before publication.
+Evidence stored in the repository tree remains subject to the explicit-redaction naming checks under `issue-evidence/`. GitHub Release assets are outside the checked-out file tree. The local doctor does not inspect or attest to their redaction, so every release asset must be reviewed separately before publication.
 
 ## Working With the Repository
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ No branch, commit, package version, tag, release, fork, artifact, or file receiv
 | `codex-issue-23192-assets` | Evidence-asset tag, not a software release |
 | Forks and historical commits | Unsupported |
 
-The two GitHub Releases contain public redacted evidence for external Codex issue reports. They do not represent supported software versions, stable builds, or compatibility commitments.
+The `codex-issue-22773-assets` release metadata explicitly identifies redacted screenshots. The `codex-issue-23192-assets` release is public screenshot evidence. Neither release represents a supported software version, stable build, or compatibility commitment, and the local doctor does not inspect or attest to either release's asset contents.
 
 ## Current Guardrails
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -75,12 +75,12 @@ CI runs the Rust doctor directly rather than placing a shell wrapper between Git
 | --- | --- |
 | `issue-evidence/` | Public issue-supporting artifacts committed to the repository tree and required to use explicit redaction naming. |
 | `issue-evidence/codex-23192-redacted/` | Current in-tree redacted evidence set for Codex issue 23192. |
-| Release tag `codex-issue-22773-assets` | Redacted screenshot asset bundle published 2026-05-15 for Codex issue 22773. |
-| Release tag `codex-issue-23192-assets` | Redacted screenshot asset bundle published 2026-05-17 for Codex issue 23192. |
+| Release tag `codex-issue-22773-assets` | Screenshot-evidence bundle published 2026-05-15 and explicitly described by its release metadata as redacted. |
+| Release tag `codex-issue-23192-assets` | Public screenshot-evidence bundle published 2026-05-17 for Codex issue 23192. |
 
 The two GitHub Releases are evidence bundles, not software releases or package versions. Their tags must not be interpreted as supported builds or semantic versions of `test-project-tbd`.
 
-The doctor rejects in-tree evidence paths that are not explicitly redacted or that use names such as `unredacted` or `nonredacted`. GitHub Release assets are outside the checked-out repository tree, so their redaction and content must be reviewed before publication rather than assumed to be covered by the local doctor.
+The doctor rejects in-tree evidence paths that are not explicitly redacted or that use names such as `unredacted` or `nonredacted`. GitHub Release assets are outside the checked-out repository tree. The local doctor neither inspects nor attests to their redaction, so every release asset requires separate review before publication.
 
 ## Generated and Local-Only Areas
 


### PR DESCRIPTION
## Summary

- Correct the README, structure map, security policy, legal notices, and changelog so release-asset redaction is claimed only where GitHub Release metadata explicitly verifies it.
- Preserve the verified distinction: `codex-issue-22773-assets` is described by its metadata as redacted screenshots, while `codex-issue-23192-assets` is public screenshot evidence.
- State consistently that the local repository doctor does not inspect or attest GitHub Release asset contents.

## Verification

- Protected `Repository smoke test` required before merge.
- The changes are documentation-only and remain subject to repository-doctor policy checks.

## Risk / Notes

- Removes an overclaim; no executable code, workflow, dependency, permission, branch-protection, release asset, or runtime behavior changed.
