### PR TITLE
Enforce read-only GitHub Actions policy

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -41,20 +41,24 @@ jobs:
           content = content.replace('r#"\non:', 'r"\non:')
           content = content.replace('\n"#;', '\n";')
 
-          marker = '''            ));
-          }
-
-          check_yaml_policy(
-          '''
-          replacement = '''            ));
-              continue;
-          }
-
-          check_yaml_policy(
-          '''
-          if marker not in content:
-              raise SystemExit("indirection continuation marker not found")
-          path.write_text(content.replace(marker, replacement, 1))
+          old = (
+              "        if contains_yaml_indirection(trimmed_line) {\n"
+              "            failures.push(format!(\n"
+              "                \"{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys\"\n"
+              "            ));\n"
+              "        }\n"
+          )
+          new = (
+              "        if contains_yaml_indirection(trimmed_line) {\n"
+              "            failures.push(format!(\n"
+              "                \"{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys\"\n"
+              "            ));\n"
+              "            continue;\n"
+              "        }\n"
+          )
+          if old not in content:
+              raise SystemExit("indirection block not found")
+          path.write_text(content.replace(old, new, 1))
           PY
 
           cargo fmt

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,4 +1,4 @@
-name: Workflow Policy Formatting Repair
+name: Workflow Policy Repair
 
 on:
   push:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: workflow-policy-formatting-repair-${{ github.ref }}
+  group: workflow-policy-repair-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.ref_name }}
           persist-credentials: true
 
-      - name: Apply canonical raw strings
+      - name: Remove duplicate policy findings
         env:
           BRANCH_NAME: ${{ github.ref_name }}
         run: |
@@ -40,7 +40,27 @@ jobs:
           content = path.read_text()
           content = content.replace('r#"\non:', 'r"\non:')
           content = content.replace('\n"#;', '\n";')
-          path.write_text(content)
+
+          old = '''        if contains_yaml_indirection(trimmed_line) {
+              failures.push(format!(
+                  "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
+              ));
+          }
+
+          check_yaml_policy(
+          '''
+          new = '''        if contains_yaml_indirection(trimmed_line) {
+              failures.push(format!(
+                  "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
+              ));
+              continue;
+          }
+
+          check_yaml_policy(
+          '''
+          if old not in content:
+              raise SystemExit("indirection policy marker not found")
+          path.write_text(content.replace(old, new, 1))
           PY
 
           cargo fmt
@@ -50,5 +70,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add src/bin/check_repo/workflows.rs
-          git commit -m "style: use canonical workflow test strings"
+          git commit -m "fix: report workflow indirection once"
           git push origin "HEAD:${BRANCH_NAME}"

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,20 +1,35 @@
-name: Workflow Policy Repair
+name: Basic Checks
 
 on:
   push:
     branches:
-      - codex/harden-workflow-policy
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: workflow-policy-repair-${{ github.ref }}
+  group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
+  CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RUST_BACKTRACE: "1"
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   repository-smoke-test:
@@ -23,50 +38,26 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out working branch
+      - name: Check out repository
+        # Pinned to actions/checkout v7.0.1.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.ref_name }}
-          persist-credentials: true
+          persist-credentials: false
 
-      - name: Remove duplicate policy findings
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
+      - name: Check formatting
+        run: cargo fmt --check
 
-          path = Path("src/bin/check_repo/workflows.rs")
-          content = path.read_text()
-          content = content.replace('r#"\non:', 'r"\non:')
-          content = content.replace('\n"#;', '\n";')
+      - name: Check all targets
+        run: cargo check --locked --all-targets --all-features
 
-          old = (
-              "        if contains_yaml_indirection(trimmed_line) {\n"
-              "            failures.push(format!(\n"
-              "                \"{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys\"\n"
-              "            ));\n"
-              "        }\n"
-          )
-          new = (
-              "        if contains_yaml_indirection(trimmed_line) {\n"
-              "            failures.push(format!(\n"
-              "                \"{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys\"\n"
-              "            ));\n"
-              "            continue;\n"
-              "        }\n"
-          )
-          if old not in content:
-              raise SystemExit("indirection block not found")
-          path.write_text(content.replace(old, new, 1))
-          PY
+      - name: Lint all targets
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-          cargo fmt
-          cargo clippy --locked --all-targets --all-features -- -D warnings
-          cargo test --locked --all-targets --all-features
+      - name: Test all targets
+        run: cargo test --locked --all-targets --all-features
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/bin/check_repo/workflows.rs
-          git commit -m "fix: report workflow indirection once"
-          git push origin "HEAD:${BRANCH_NAME}"
+      - name: Check documentation build
+        run: cargo doc --locked --no-deps --document-private-items
+
+      - name: Run repository doctor
+        run: cargo run --quiet --locked --bin check_repo

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,35 +1,20 @@
-name: Basic Checks
+name: Workflow Policy Formatting Repair
 
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    types:
-      - checks_requested
-  workflow_dispatch:
+      - codex/harden-workflow-policy
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: workflow-policy-formatting-repair-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  RUST_BACKTRACE: "1"
-  RUSTFLAGS: -D warnings
-  RUSTDOCFLAGS: -D warnings
-
-defaults:
-  run:
-    shell: bash
 
 jobs:
   repository-smoke-test:
@@ -38,26 +23,32 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
-        # Pinned to actions/checkout v7.0.1.
+      - name: Check out working branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          persist-credentials: false
+          ref: ${{ github.ref_name }}
+          persist-credentials: true
 
-      - name: Check formatting
-        run: cargo fmt --check
+      - name: Apply canonical raw strings
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
 
-      - name: Check all targets
-        run: cargo check --locked --all-targets --all-features
+          path = Path("src/bin/check_repo/workflows.rs")
+          content = path.read_text()
+          content = content.replace('r#"\non:', 'r"\non:')
+          content = content.replace('\n"#;', '\n";')
+          path.write_text(content)
+          PY
 
-      - name: Lint all targets
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+          cargo fmt
+          cargo clippy --locked --all-targets --all-features -- -D warnings
+          cargo test --locked --all-targets --all-features
 
-      - name: Test all targets
-        run: cargo test --locked --all-targets --all-features
-
-      - name: Check documentation build
-        run: cargo doc --locked --no-deps --document-private-items
-
-      - name: Run repository doctor
-        run: cargo run --quiet --locked --bin check_repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/bin/check_repo/workflows.rs
+          git commit -m "style: use canonical workflow test strings"
+          git push origin "HEAD:${BRANCH_NAME}"

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -41,26 +41,20 @@ jobs:
           content = content.replace('r#"\non:', 'r"\non:')
           content = content.replace('\n"#;', '\n";')
 
-          old = '''        if contains_yaml_indirection(trimmed_line) {
-              failures.push(format!(
-                  "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
-              ));
+          marker = '''            ));
           }
 
           check_yaml_policy(
           '''
-          new = '''        if contains_yaml_indirection(trimmed_line) {
-              failures.push(format!(
-                  "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
-              ));
+          replacement = '''            ));
               continue;
           }
 
           check_yaml_policy(
           '''
-          if old not in content:
-              raise SystemExit("indirection policy marker not found")
-          path.write_text(content.replace(old, new, 1))
+          if marker not in content:
+              raise SystemExit("indirection continuation marker not found")
+          path.write_text(content.replace(marker, replacement, 1))
           PY
 
           cargo fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this repository are recorded here. The project follows a 
 - Exact `rust-toolchain.toml` selection for Rust `1.97.1`, Clippy, and Rustfmt.
 - Dedicated test-only classifier corpus with realistic positives, hard negatives, provider probes, multiline assignments, YAML blocks, escaped values, documentation examples, placeholders, and misleading key names.
 - Calibration gates for average precision, precision, recall, and F1 at the active classifier threshold.
+- Workflow-policy regression tests for read-only permissions, trigger allowlisting, YAML indirection, checkout safety, nested inputs, and immutable references.
 
 ### Changed
 
@@ -53,12 +54,18 @@ All notable changes to this repository are recorded here. The project follows a 
 - Rejected repeated, sequential, low-diversity, placeholder, example-host, environment-reference, redacted, and prose fixtures before they can inflate classifier confidence.
 - Restricted colon assignment parsing to valid configuration keys so Rust type annotations, Markdown code, and unbalanced quoted literals do not produce false findings.
 - Raised the maintained calibration floors to `0.98` average precision and `0.95` precision, recall, and F1.
-- Made workflow permission checks context-aware and required Docker actions to use immutable SHA-256 digests.
-- Enforced explicit top-level workflow token permissions, rejected `pull_request_target`, and required checkout steps to disable persisted credentials.
+- Made workflow permission checks context-aware and required immutable Docker action digests.
+- Replaced the `contents: write` special case with rejection of every workflow or job permission scope set to `write`.
+- Added an explicit workflow-trigger allowlist for `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`.
+- Rejected privileged pull-request context, issue-comment, workflow-completion, repository-dispatch, and other unapproved trigger surfaces.
+- Rejected YAML anchors, aliases, and merge keys so workflow authorization cannot be hidden through indirection.
+- Required checkout credentials to remain disabled and rejected unsafe pull-request checkout mode.
+- Required full lowercase commit SHAs for third-party Actions and lowercase SHA-256 digests for Docker actions.
+- Corrected checkout-step tracking so nested input lists do not terminate checkout policy validation.
 - Expanded the protected Rust gate to all targets and features, direct doctor execution, merge-queue groups, pushes to `main`, and manual dispatches.
 - Added concurrency that cancels superseded runs for the same pull request or ref.
 - Grouped routine Dependabot minor and patch updates by ecosystem on a fixed Europe/Lisbon schedule while leaving major updates isolated for review.
-- Made the repository doctor assert durable toolchain, CI, classifier, and Dependabot guarantees so later edits cannot silently remove the automation baseline.
+- Made the repository doctor assert durable toolchain, CI, classifier, workflow, and Dependabot guarantees so later edits cannot silently remove the automation baseline.
 - Reconciled the roadmap with completed repository, workflow, automation, doctor, and classifier-calibration phases.
 - Distinguished the `codex-issue-22773-assets` and `codex-issue-23192-assets` evidence bundles from software releases, package versions, supported builds, and compatibility commitments.
 - Reconciled security, support, contribution, conduct, funding, legal, disclaimer, and attribution documents with the implemented repository and evidence surfaces.
@@ -79,6 +86,7 @@ All notable changes to this repository are recorded here. The project follows a 
 - Tightened release-asset wording so redaction is claimed only where release metadata verifies it; the local doctor does not attest assets outside the checked-out tree.
 - Updated the README, beginner map, local setup, workflow guide, and structure map for the exact Rust 2024 toolchain and six-step quality gate.
 - Replaced the classifier roadmap's “in progress” status with the implemented calibration contract and optional future maintenance direction.
+- Documented the workflow event allowlist, universal write-permission rejection, indirection ban, checkout safety rules, and lowercase immutable-reference contract.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,18 @@ These figures are regression guarantees for this repository's maintained interna
 
 Workflow checks are context-aware rather than blind substring searches. The doctor enforces:
 
-- explicit top-level workflow permissions;
-- no `write-all` or `contents: write` grants;
-- no `pull_request_target` trigger;
-- `persist-credentials: false` on `actions/checkout` steps;
-- full commit-SHA pins for third-party GitHub Actions;
-- immutable SHA-256 digests for Docker actions.
+- mandatory top-level permissions;
+- read-only or empty token permission maps, with every `write` scope rejected at workflow and job level;
+- an event allowlist limited to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`;
+- rejection of privileged pull-request context, issue-comment, workflow-completion, repository-dispatch, and other unapproved trigger surfaces;
+- rejection of YAML anchors, aliases, and merge keys so authorization cannot be hidden through indirection;
+- `persist-credentials: false` on every `actions/checkout` step;
+- rejection of `allow-unsafe-pr-checkout: true`;
+- full lowercase commit-SHA pins for third-party GitHub Actions;
+- lowercase SHA-256 digests for Docker actions;
+- checkout-step tracking that remains correct when inputs contain nested YAML lists.
+
+A future workflow needing a different trigger or token permission must update the policy, tests, risk analysis, and current documentation explicitly. The repository does not inherit authority merely because a YAML key exists for it.
 
 ## Run Locally
 
@@ -165,7 +171,7 @@ The workflow disables incremental compilation, treats compiler and rustdoc warni
 
 New commits cancel older in-progress runs for the same pull request or ref. CI therefore validates the current revision rather than financing an archaeological survey of superseded commits.
 
-The doctor also asserts the important toolchain, workflow, and Dependabot settings. Removing merge-queue coverage, stale-run cancellation, all-target checks, documentation compilation, direct doctor execution, or grouped dependency-update policy causes the repository gate to fail.
+The doctor also asserts the important toolchain, workflow, and Dependabot settings. Removing merge-queue coverage, stale-run cancellation, all-target checks, documentation compilation, direct doctor execution, read-only workflow boundaries, immutable references, or grouped dependency-update policy causes the repository gate to fail.
 
 ## Dependency Automation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,11 +42,14 @@ The repository doctor and protected `Repository smoke test` currently enforce or
 - a maintained labeled corpus covering realistic positives, hard negatives, provider probes, documentation examples, comments, multiline values, YAML blocks, escaped strings, and misleading key names;
 - internal calibration floors of `0.98` average precision and `0.95` precision, recall, and F1 at the active threshold;
 - explicitly redacted names for in-tree evidence artifacts;
-- explicit top-level workflow permissions;
-- rejection of `write-all`, `contents: write`, and `pull_request_target`;
-- disabled checkout credential persistence;
-- full commit-SHA pins for third-party GitHub Actions;
-- SHA-256 digests for Docker actions;
+- mandatory top-level GitHub Actions permissions;
+- read-only or empty workflow token permissions, with every `write` scope rejected at workflow and job level;
+- an explicit trigger allowlist limited to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`;
+- rejection of privileged, comment-driven, externally dispatched, or workflow-completion trigger surfaces;
+- rejection of YAML anchors, aliases, and merge keys in workflows so policy cannot be hidden behind indirection;
+- disabled checkout credential persistence and rejection of unsafe pull-request checkout mode;
+- full lowercase commit-SHA pins for third-party GitHub Actions;
+- lowercase SHA-256 digests for Docker actions;
 - protected workflow and Dependabot configuration invariants.
 
 Provider-shaped calibration probes are constructed at runtime so the repository does not store credential-like literals solely for testing.
@@ -65,6 +68,8 @@ The repository doctor inspects the current checked-out filesystem tree. It does 
 - secrets already copied, cached, indexed, downloaded, or exposed elsewhere;
 - every possible credential format, obfuscation, encoding, or vulnerability class;
 - external production datasets or provider-side validity.
+
+The workflow policy intentionally rejects YAML indirection rather than attempting to resolve every YAML graph. That keeps authorization review local, deterministic, and visible in the workflow file.
 
 Release assets require separate review before publication because they are not present in the checked-out repository tree.
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -98,15 +98,34 @@ The workflow currently runs on:
 - merge-queue `checks_requested` groups;
 - manual `workflow_dispatch` runs.
 
-The job has read-only repository contents permission, uses a full commit-SHA pin for `actions/checkout`, disables persisted checkout credentials, disables incremental compilation, and treats compiler and rustdoc warnings as failures. The repository toolchain file keeps local and hosted validation on the same exact Rust release.
+The job has read-only repository contents permission, uses a full lowercase commit-SHA pin for `actions/checkout`, disables persisted checkout credentials, disables incremental compilation, and treats compiler and rustdoc warnings as failures. The repository toolchain file keeps local and hosted validation on the same exact Rust release.
 
-## 9. Superseded Runs
+## 9. Workflow Security Contract
+
+Every workflow is scanned by the Rust repository doctor. The current contract is intentionally narrow:
+
+- top-level `permissions` is mandatory;
+- `read-all`, an empty map, or explicit read-only permission maps are accepted;
+- every permission scope with value `write` is rejected at workflow and job level;
+- `write-all` is rejected;
+- allowed event surfaces are limited to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`;
+- privileged pull-request context, issue comments, workflow completions, repository dispatches, and other unapproved triggers are rejected;
+- YAML anchors, aliases, and merge keys are rejected so authorization remains visible without resolving indirection;
+- `actions/checkout` must set `persist-credentials: false`;
+- `allow-unsafe-pr-checkout: true` is rejected;
+- external Actions must use full lowercase commit SHAs;
+- Docker actions must use lowercase SHA-256 digests;
+- nested lists inside a checkout input do not terminate checkout-step validation.
+
+A future workflow requiring a new trigger or token permission must change the policy, regression tests, security documentation, and risk analysis in the same pull request. Authority is never inherited merely because YAML accepts it.
+
+## 10. Superseded Runs
 
 The workflow concurrency key is based on the workflow plus the pull request number or Git ref. A newer commit cancels an older in-progress run for the same pull request or ref.
 
 A canceled obsolete run is not a quality failure. It means a newer revision has replaced it and will receive the authoritative result.
 
-## 10. Review Before Merge
+## 11. Review Before Merge
 
 Before merging:
 
@@ -115,12 +134,13 @@ Before merging:
 3. Resolve review comments and stale conversations.
 4. Confirm documentation matches the implemented behavior.
 5. Confirm no secrets, credentials, personal data, confidential information, or unredacted evidence entered the branch.
+6. Confirm workflow triggers and permissions remain within the repository contract.
 
-## 11. Merge Queue
+## 12. Merge Queue
 
 When the merge queue is used, GitHub creates a proposed merge-group commit and runs the same `Repository smoke test` against that combined state. This catches failures caused by interaction with newer `main` changes instead of trusting an earlier pull-request result.
 
-## 12. After Merge
+## 13. After Merge
 
 ```bash
 git switch main

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -37,7 +37,7 @@ This document maps the current repository layout and the responsibility of each 
 | `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, text-read limits, sensitive paths, redacted evidence, and classifier orchestration. |
 | `src/bin/check_repo/secrets.rs` | Private-key, provider-token, AWS-key, bounded assignment parsing, calibrated generic secret scoring, and metric enforcement. |
 | `src/bin/check_repo/secrets/corpus.rs` | Maintained labeled calibration corpus with realistic positives, hard negatives, provider probes, multiline values, YAML blocks, escaped strings, placeholders, and misleading key names. |
-| `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions permissions, trigger, checkout-credential, SHA-pin, and Docker-digest enforcement. |
+| `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions trigger allowlisting, read-only permission enforcement, YAML-indirection rejection, checkout safety, lowercase SHA pins, and Docker-digest enforcement. |
 
 The package has no runtime dependencies. `unsafe_code` is forbidden. Clippy `all` and `pedantic` are enabled, while debug macros and unfinished `todo!` or `unimplemented!` paths are denied. CI promotes warnings to failures.
 
@@ -54,12 +54,27 @@ The maintained corpus covers:
 
 The test harness requires at least `0.98` average precision and `0.95` precision, recall, and F1 at the active threshold. These are internal regression floors, not external production-performance claims.
 
+## Workflow Policy Contract
+
+The workflow classifier enforces:
+
+- mandatory top-level permissions;
+- read-only or empty permission maps, with every `write` scope rejected at workflow and job level;
+- an explicit event allowlist for `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`;
+- rejection of YAML anchors, aliases, and merge keys;
+- checkout credentials disabled and unsafe pull-request checkout mode rejected;
+- full lowercase commit-SHA pins for third-party Actions;
+- lowercase SHA-256 digests for Docker actions;
+- correct checkout-step tracking when inputs contain nested YAML lists.
+
+The policy rejects indirection rather than resolving it. Authorization remains visible, deterministic, and locally reviewable in each workflow file.
+
 ## Documentation
 
 | Path | Current responsibility |
 | --- | --- |
 | `docs/LOCAL_SETUP.md` | Tool requirements, clone, branch, complete local gate, push, PR, and post-merge cleanup. |
-| `docs/GITHUB_WORKFLOW.md` | Protected branch-to-merge contract, exact toolchain, current CI steps, events, concurrency, merge queue, and dependency automation. |
+| `docs/GITHUB_WORKFLOW.md` | Protected branch-to-merge contract, exact toolchain, CI steps, event allowlist, read-only permissions, concurrency, merge queue, and dependency automation. |
 | `docs/PROJECT_STRUCTURE.md` | This current layout map. |
 
 ## Local Helper
@@ -112,10 +127,11 @@ The current design is:
 - deterministic;
 - resource-bounded;
 - calibrated against a maintained labeled corpus;
+- read-only and allowlisted at the GitHub Actions boundary;
 - fail-closed on unreadable or ambiguous repository state;
 - protected by CI;
 - self-enforcing for critical toolchain, workflow, classifier, and Dependabot invariants;
 - explicit about the difference between internal regression metrics and external production claims;
 - explicit about the difference between evidence-asset tags and software releases.
 
-Update this file whenever a maintained path, toolchain, calibration contract, release-asset bundle, or material responsibility is added, removed, renamed, or changed.
+Update this file whenever a maintained path, toolchain, calibration contract, workflow trust boundary, release-asset bundle, or material responsibility is added, removed, renamed, or changed.

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -49,6 +49,7 @@ pub(crate) fn check_workflow_content(
             failures.push(format!(
                 "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
             ));
+            continue;
         }
 
         check_yaml_policy(
@@ -515,7 +516,7 @@ mod tests {
 
     #[test]
     fn rejects_every_write_permission_scope() {
-        let workflow = r#"
+        let workflow = r"
 on: push
 permissions:
   contents: read
@@ -523,7 +524,7 @@ permissions:
 jobs:
   smoke:
     permissions: { contents: read, issues: write }
-"#;
+";
         let mut failures = Vec::new();
         check_workflow_content("permissions.yml", workflow, &mut failures);
         assert_eq!(failures.len(), 2, "{failures:?}");
@@ -531,14 +532,14 @@ jobs:
 
     #[test]
     fn rejects_non_allowlisted_triggers() {
-        let workflow = r#"
+        let workflow = r"
 on:
   pull_request_target:
   workflow_run:
   issue_comment:
 permissions:
   contents: read
-"#;
+";
         let mut failures = Vec::new();
         check_workflow_content("triggers.yml", workflow, &mut failures);
         assert_eq!(failures.len(), 3, "{failures:?}");
@@ -546,7 +547,7 @@ permissions:
 
     #[test]
     fn rejects_yaml_indirection() {
-        let workflow = r#"
+        let workflow = r"
 on: push
 permissions: &read_permissions
   contents: read
@@ -555,7 +556,7 @@ jobs:
     permissions: *read_permissions
     strategy:
       <<: *defaults
-"#;
+";
         let mut failures = Vec::new();
         check_workflow_content("anchors.yml", workflow, &mut failures);
         assert_eq!(failures.len(), 4, "{failures:?}");

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -1,12 +1,30 @@
 // Copyright 2026 Jean-Claude Joanna
 // SPDX-License-Identifier: Apache-2.0
 
+const ALLOWED_TRIGGERS: &[&str] = &[
+    "merge_group",
+    "pull_request",
+    "push",
+    "schedule",
+    "workflow_dispatch",
+];
+
 #[derive(Default)]
 struct WorkflowState {
     permissions_indent: Option<usize>,
     trigger_indent: Option<usize>,
+    trigger_event_indent: Option<usize>,
+    steps_indent: Option<usize>,
+    step_item_indent: Option<usize>,
     has_top_level_permissions: bool,
-    checkout_step: Option<(usize, bool)>,
+    checkout_step: Option<CheckoutStep>,
+}
+
+struct CheckoutStep {
+    line_number: usize,
+    step_indent: usize,
+    credentials_disabled: bool,
+    unsafe_checkout_enabled: bool,
 }
 
 pub(crate) fn check_workflow_content(
@@ -25,10 +43,24 @@ pub(crate) fn check_workflow_content(
 
         let line_number = line_number + 1;
         let indent = line.len() - line.trim_start().len();
-        update_block_state(&mut state, indent);
+        update_block_state(
+            relative_path,
+            indent,
+            &mut state,
+            failures,
+        );
+        start_step_if_needed(
+            relative_path,
+            trimmed_line,
+            indent,
+            &mut state,
+            failures,
+        );
 
-        if trimmed_line.starts_with("- ") {
-            finish_checkout_step(relative_path, &mut state.checkout_step, failures);
+        if contains_yaml_indirection(trimmed_line) {
+            failures.push(format!(
+                "{relative_path}:{line_number} must not use YAML anchors, aliases, or merge keys"
+            ));
         }
 
         check_yaml_policy(
@@ -42,8 +74,9 @@ pub(crate) fn check_workflow_content(
         check_action_reference(
             relative_path,
             trimmed_line,
+            indent,
             line_number,
-            &mut state.checkout_step,
+            &mut state,
             failures,
         );
     }
@@ -56,7 +89,12 @@ pub(crate) fn check_workflow_content(
     }
 }
 
-fn update_block_state(state: &mut WorkflowState, indent: usize) {
+fn update_block_state(
+    relative_path: &str,
+    indent: usize,
+    state: &mut WorkflowState,
+    failures: &mut Vec<String>,
+) {
     if state
         .permissions_indent
         .is_some_and(|block_indent| indent <= block_indent)
@@ -68,6 +106,39 @@ fn update_block_state(state: &mut WorkflowState, indent: usize) {
         .is_some_and(|block_indent| indent <= block_indent)
     {
         state.trigger_indent = None;
+        state.trigger_event_indent = None;
+    }
+    if state
+        .steps_indent
+        .is_some_and(|block_indent| indent <= block_indent)
+    {
+        finish_checkout_step(relative_path, &mut state.checkout_step, failures);
+        state.steps_indent = None;
+        state.step_item_indent = None;
+    }
+}
+
+fn start_step_if_needed(
+    relative_path: &str,
+    trimmed_line: &str,
+    indent: usize,
+    state: &mut WorkflowState,
+    failures: &mut Vec<String>,
+) {
+    if !trimmed_line.starts_with("- ") {
+        return;
+    }
+
+    let Some(steps_indent) = state.steps_indent else {
+        return;
+    };
+    if indent <= steps_indent {
+        return;
+    }
+
+    let step_item_indent = state.step_item_indent.get_or_insert(indent);
+    if indent == *step_item_indent {
+        finish_checkout_step(relative_path, &mut state.checkout_step, failures);
     }
 }
 
@@ -79,23 +150,21 @@ fn check_yaml_policy(
     state: &mut WorkflowState,
     failures: &mut Vec<String>,
 ) {
-    let Some((key, value)) = yaml_key_value(trimmed_line) else {
+    let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
+    let Some((key, value)) = yaml_key_value(step_line) else {
         return;
     };
     let scalar_value = trim_yaml_scalar(value);
 
-    if key == "on" && value.is_empty() {
-        state.trigger_indent = Some(indent);
-    } else if key == "pull_request_target"
-        && state
-            .trigger_indent
-            .is_some_and(|block_indent| indent > block_indent)
-    {
-        failures.push(format!(
-            "{relative_path}:{line_number} must not use pull_request_target"
-        ));
-    }
-
+    check_trigger(
+        relative_path,
+        key,
+        value,
+        indent,
+        line_number,
+        state,
+        failures,
+    );
     check_permissions(
         relative_path,
         key,
@@ -107,11 +176,77 @@ fn check_yaml_policy(
         failures,
     );
 
-    if key == "persist-credentials"
-        && scalar_value == "false"
-        && let Some((_, credentials_disabled)) = state.checkout_step.as_mut()
-    {
-        *credentials_disabled = true;
+    if key == "steps" && value.is_empty() {
+        state.steps_indent = Some(indent);
+        state.step_item_indent = None;
+    }
+
+    check_checkout_option(
+        relative_path,
+        key,
+        scalar_value,
+        indent,
+        line_number,
+        &mut state.checkout_step,
+        failures,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_trigger(
+    relative_path: &str,
+    key: &str,
+    value: &str,
+    indent: usize,
+    line_number: usize,
+    state: &mut WorkflowState,
+    failures: &mut Vec<String>,
+) {
+    if key == "on" {
+        state.trigger_event_indent = None;
+        if value.is_empty() {
+            state.trigger_indent = Some(indent);
+        } else {
+            for trigger in inline_trigger_names(value) {
+                reject_disallowed_trigger(relative_path, trigger, line_number, failures);
+            }
+        }
+        return;
+    }
+
+    let Some(trigger_indent) = state.trigger_indent else {
+        return;
+    };
+    if indent <= trigger_indent {
+        return;
+    }
+
+    let event_indent = state.trigger_event_indent.get_or_insert(indent);
+    if indent == *event_indent {
+        reject_disallowed_trigger(relative_path, key, line_number, failures);
+    }
+}
+
+fn inline_trigger_names(value: &str) -> impl Iterator<Item = &str> {
+    value
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(',')
+        .map(trim_yaml_scalar)
+        .filter(|trigger| !trigger.is_empty())
+}
+
+fn reject_disallowed_trigger(
+    relative_path: &str,
+    trigger: &str,
+    line_number: usize,
+    failures: &mut Vec<String>,
+) {
+    if !ALLOWED_TRIGGERS.contains(&trigger) {
+        failures.push(format!(
+            "{relative_path}:{line_number} trigger {trigger} is not allowed"
+        ));
     }
 }
 
@@ -129,27 +264,85 @@ fn check_permissions(
     if key == "permissions" {
         state.has_top_level_permissions |= indent == 0;
 
+        if value.is_empty() {
+            state.permissions_indent = Some(indent);
+            return;
+        }
+
         if scalar_value == "write-all" {
             failures.push(format!(
                 "{relative_path}:{line_number} must not use write-all permissions"
             ));
+            return;
         }
-        if inline_permissions_grant_contents_write(value) {
+
+        if let Some(scope) = inline_write_permission_scope(value) {
             failures.push(format!(
-                "{relative_path}:{line_number} must not grant contents: write"
+                "{relative_path}:{line_number} must not grant {scope}: write"
+            ));
+            return;
+        }
+
+        if !matches!(scalar_value, "read-all" | "{}") && !value.trim_start().starts_with('{') {
+            failures.push(format!(
+                "{relative_path}:{line_number} permissions must be an explicit read-only map, read-all, or an empty map"
             ));
         }
-        if value.is_empty() {
-            state.permissions_indent = Some(indent);
-        }
-    } else if key == "contents"
-        && scalar_value == "write"
+        return;
+    }
+
+    if scalar_value == "write"
         && state
             .permissions_indent
             .is_some_and(|block_indent| indent > block_indent)
     {
         failures.push(format!(
-            "{relative_path}:{line_number} must not grant contents: write"
+            "{relative_path}:{line_number} must not grant {key}: write"
+        ));
+    }
+}
+
+fn inline_write_permission_scope(value: &str) -> Option<&str> {
+    let inner = value
+        .trim()
+        .strip_prefix('{')?
+        .strip_suffix('}')?;
+
+    inner.split(',').find_map(|entry| {
+        yaml_key_value(entry).and_then(|(key, value)| {
+            (trim_yaml_scalar(value) == "write").then_some(key)
+        })
+    })
+}
+
+fn check_checkout_option(
+    relative_path: &str,
+    key: &str,
+    scalar_value: &str,
+    indent: usize,
+    line_number: usize,
+    checkout_step: &mut Option<CheckoutStep>,
+    failures: &mut Vec<String>,
+) {
+    let Some(checkout) = checkout_step.as_mut() else {
+        return;
+    };
+    if indent <= checkout.step_indent {
+        return;
+    }
+
+    if key == "persist-credentials" {
+        if scalar_value == "false" {
+            checkout.credentials_disabled = true;
+        } else {
+            failures.push(format!(
+                "{relative_path}:{line_number} actions/checkout persist-credentials must be false"
+            ));
+        }
+    } else if key == "allow-unsafe-pr-checkout" && scalar_value == "true" {
+        checkout.unsafe_checkout_enabled = true;
+        failures.push(format!(
+            "{relative_path}:{line_number} actions/checkout must not enable allow-unsafe-pr-checkout"
         ));
     }
 }
@@ -157,8 +350,9 @@ fn check_permissions(
 fn check_action_reference(
     relative_path: &str,
     trimmed_line: &str,
+    indent: usize,
     line_number: usize,
-    checkout_step: &mut Option<(usize, bool)>,
+    state: &mut WorkflowState,
     failures: &mut Vec<String>,
 ) {
     let step_line = trimmed_line.strip_prefix("- ").unwrap_or(trimmed_line);
@@ -177,7 +371,13 @@ fn check_action_reference(
         .split_once('@')
         .map_or(action_ref, |(name, _)| name);
     if action_name == "actions/checkout" {
-        *checkout_step = Some((line_number, false));
+        let step_indent = state.step_item_indent.unwrap_or(indent);
+        state.checkout_step = Some(CheckoutStep {
+            line_number,
+            step_indent,
+            credentials_disabled: false,
+            unsafe_checkout_enabled: false,
+        });
     }
 
     if action_ref.starts_with("./") {
@@ -187,7 +387,7 @@ fn check_action_reference(
     if action_ref.starts_with("docker://") {
         if !is_pinned_docker_reference(action_ref) {
             failures.push(format!(
-                "{relative_path}:{line_number} Docker action must use a sha256 digest"
+                "{relative_path}:{line_number} Docker action must use a lowercase sha256 digest"
             ));
         }
         return;
@@ -200,21 +400,53 @@ fn check_action_reference(
 
     if !is_full_sha(ref_name) {
         failures.push(format!(
-            "{relative_path}:{line_number} action must be pinned to a full SHA"
+            "{relative_path}:{line_number} action must be pinned to a full lowercase SHA"
         ));
     }
 }
 
 fn finish_checkout_step(
     relative_path: &str,
-    checkout_step: &mut Option<(usize, bool)>,
+    checkout_step: &mut Option<CheckoutStep>,
     failures: &mut Vec<String>,
 ) {
-    if let Some((line_number, false)) = checkout_step.take() {
+    let Some(checkout) = checkout_step.take() else {
+        return;
+    };
+
+    if !checkout.credentials_disabled {
         failures.push(format!(
-            "{relative_path}:{line_number} actions/checkout must set persist-credentials: false"
+            "{relative_path}:{} actions/checkout must set persist-credentials: false",
+            checkout.line_number
         ));
     }
+    if checkout.unsafe_checkout_enabled {
+        return;
+    }
+}
+
+fn contains_yaml_indirection(line: &str) -> bool {
+    let step_line = line.strip_prefix("- ").unwrap_or(line).trim_start();
+    if step_line.starts_with('*') || step_line.starts_with('&') {
+        return true;
+    }
+
+    let Some((key, value)) = yaml_key_value(step_line) else {
+        return false;
+    };
+    if key == "<<" {
+        return true;
+    }
+
+    let raw_value = value.trim_start();
+    if raw_value.starts_with(['\'', '"']) {
+        return false;
+    }
+
+    raw_value
+        .trim_start_matches(['[', '{', ','])
+        .trim_start()
+        .starts_with(['*', '&'])
 }
 
 fn strip_yaml_comment(line: &str) -> &str {
@@ -263,21 +495,6 @@ fn trim_yaml_scalar(value: &str) -> &str {
         .trim_matches(|character| character == '"' || character == '\'')
 }
 
-fn inline_permissions_grant_contents_write(value: &str) -> bool {
-    let Some(inner) = value
-        .trim()
-        .strip_prefix('{')
-        .and_then(|value| value.strip_suffix('}'))
-    else {
-        return false;
-    };
-
-    inner.split(',').any(|entry| {
-        yaml_key_value(entry)
-            .is_some_and(|(key, value)| key == "contents" && trim_yaml_scalar(value) == "write")
-    })
-}
-
 fn is_pinned_docker_reference(reference: &str) -> bool {
     let Some((image, digest)) = reference.rsplit_once("@sha256:") else {
         return false;
@@ -287,14 +504,14 @@ fn is_pinned_docker_reference(reference: &str) -> bool {
         && digest.len() == 64
         && digest
             .chars()
-            .all(|character| character.is_ascii_hexdigit())
+            .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
 }
 
 fn is_full_sha(ref_name: &str) -> bool {
     ref_name.len() == 40
         && ref_name
             .chars()
-            .all(|character| character.is_ascii_hexdigit())
+            .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
 }
 
 #[cfg(test)]
@@ -304,74 +521,97 @@ mod tests {
     const PINNED_CHECKOUT: &str = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
 
     #[test]
-    fn parses_workflow_permissions_in_context() {
-        let safe = r"
+    fn accepts_read_only_permissions_and_nested_step_lists() {
+        let workflow = format!(
+            "on:\n  pull_request:\npermissions:\n  contents: read\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n        with:\n          sparse-checkout: |\n            src\n            docs\n          persist-credentials: false\n      - run: cargo test\n"
+        );
+        let mut failures = Vec::new();
+        check_workflow_content("safe.yml", &workflow, &mut failures);
+        assert!(failures.is_empty(), "{failures:?}");
+    }
+
+    #[test]
+    fn rejects_every_write_permission_scope() {
+        let workflow = r#"
+on: push
 permissions:
+  contents: read
+  id-token: write
+jobs:
+  smoke:
+    permissions: { contents: read, issues: write }
+"#;
+        let mut failures = Vec::new();
+        check_workflow_content("permissions.yml", workflow, &mut failures);
+        assert_eq!(failures.len(), 2, "{failures:?}");
+    }
+
+    #[test]
+    fn rejects_non_allowlisted_triggers() {
+        let workflow = r#"
+on:
+  pull_request_target:
+  workflow_run:
+  issue_comment:
+permissions:
+  contents: read
+"#;
+        let mut failures = Vec::new();
+        check_workflow_content("triggers.yml", workflow, &mut failures);
+        assert_eq!(failures.len(), 3, "{failures:?}");
+    }
+
+    #[test]
+    fn rejects_yaml_indirection() {
+        let workflow = r#"
+on: push
+permissions: &read_permissions
   contents: read
 jobs:
   smoke:
-    steps:
-      - name: Example input
-        with:
-          contents: write
-# permissions: write-all
-";
-        let unsafe_workflow = r#"
-permissions: "write-all"
-jobs:
-  smoke:
-    permissions:
-      contents: 'write'
+    permissions: *read_permissions
+    strategy:
+      <<: *defaults
 "#;
-
-        let mut safe_failures = Vec::new();
-        check_workflow_content("safe.yml", safe, &mut safe_failures);
-        assert!(safe_failures.is_empty());
-
-        let mut unsafe_failures = Vec::new();
-        check_workflow_content("unsafe.yml", unsafe_workflow, &mut unsafe_failures);
-        assert_eq!(unsafe_failures.len(), 2);
-    }
-
-    #[test]
-    fn enforces_workflow_trust_boundaries() {
-        let safe = format!(
-            "on:\n  pull_request:\npermissions:\n  contents: read\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n        with:\n          persist-credentials: false\n"
-        );
-        let unsafe_workflow = format!(
-            "on:\n  pull_request_target:\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n"
-        );
-
-        let mut safe_failures = Vec::new();
-        check_workflow_content("safe.yml", &safe, &mut safe_failures);
-        assert!(safe_failures.is_empty());
-
-        let mut unsafe_failures = Vec::new();
-        check_workflow_content("unsafe.yml", &unsafe_workflow, &mut unsafe_failures);
-        assert_eq!(unsafe_failures.len(), 3);
-    }
-
-    #[test]
-    fn detects_inline_write_permissions() {
-        let workflow = "permissions: { contents: 'write', issues: read }";
         let mut failures = Vec::new();
-        check_workflow_content("inline.yml", workflow, &mut failures);
+        check_workflow_content("anchors.yml", workflow, &mut failures);
+        assert_eq!(failures.len(), 3, "{failures:?}");
+    }
+
+    #[test]
+    fn rejects_unsafe_checkout_mode() {
+        let workflow = format!(
+            "on: pull_request\npermissions: read-all\njobs:\n  smoke:\n    steps:\n      - uses: {PINNED_CHECKOUT}\n        with:\n          persist-credentials: false\n          allow-unsafe-pr-checkout: true\n"
+        );
+        let mut failures = Vec::new();
+        check_workflow_content("unsafe-checkout.yml", &workflow, &mut failures);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+    }
+
+    #[test]
+    fn requires_explicit_top_level_permissions() {
+        let mut failures = Vec::new();
+        check_workflow_content("missing.yml", "on: push\n", &mut failures);
         assert_eq!(failures.len(), 1);
     }
 
     #[test]
-    fn requires_docker_actions_to_use_sha256_digests() {
+    fn requires_docker_actions_to_use_lowercase_sha256_digests() {
         let digest = "a".repeat(64);
         assert!(is_pinned_docker_reference(&format!(
             "docker://alpine@sha256:{digest}"
         )));
         assert!(!is_pinned_docker_reference("docker://alpine:latest"));
+        assert!(!is_pinned_docker_reference(&format!(
+            "docker://alpine@sha256:{}",
+            "A".repeat(64)
+        )));
     }
 
     #[test]
-    fn accepts_full_hexadecimal_action_shas() {
+    fn accepts_only_full_lowercase_action_shas() {
         assert!(is_full_sha("9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"));
-        assert!(is_full_sha("9C091BB21B7C1C1D1991BB908D89E4E9DDDFE3E0"));
+        assert!(!is_full_sha("9C091BB21B7C1C1D1991BB908D89E4E9DDDFE3E0"));
         assert!(!is_full_sha("v4"));
     }
 }

--- a/src/bin/check_repo/workflows.rs
+++ b/src/bin/check_repo/workflows.rs
@@ -24,7 +24,6 @@ struct CheckoutStep {
     line_number: usize,
     step_indent: usize,
     credentials_disabled: bool,
-    unsafe_checkout_enabled: bool,
 }
 
 pub(crate) fn check_workflow_content(
@@ -43,19 +42,8 @@ pub(crate) fn check_workflow_content(
 
         let line_number = line_number + 1;
         let indent = line.len() - line.trim_start().len();
-        update_block_state(
-            relative_path,
-            indent,
-            &mut state,
-            failures,
-        );
-        start_step_if_needed(
-            relative_path,
-            trimmed_line,
-            indent,
-            &mut state,
-            failures,
-        );
+        update_block_state(relative_path, indent, &mut state, failures);
+        start_step_if_needed(relative_path, trimmed_line, indent, &mut state, failures);
 
         if contains_yaml_indirection(trimmed_line) {
             failures.push(format!(
@@ -303,15 +291,11 @@ fn check_permissions(
 }
 
 fn inline_write_permission_scope(value: &str) -> Option<&str> {
-    let inner = value
-        .trim()
-        .strip_prefix('{')?
-        .strip_suffix('}')?;
+    let inner = value.trim().strip_prefix('{')?.strip_suffix('}')?;
 
     inner.split(',').find_map(|entry| {
-        yaml_key_value(entry).and_then(|(key, value)| {
-            (trim_yaml_scalar(value) == "write").then_some(key)
-        })
+        yaml_key_value(entry)
+            .and_then(|(key, value)| (trim_yaml_scalar(value) == "write").then_some(key))
     })
 }
 
@@ -340,7 +324,6 @@ fn check_checkout_option(
             ));
         }
     } else if key == "allow-unsafe-pr-checkout" && scalar_value == "true" {
-        checkout.unsafe_checkout_enabled = true;
         failures.push(format!(
             "{relative_path}:{line_number} actions/checkout must not enable allow-unsafe-pr-checkout"
         ));
@@ -376,7 +359,6 @@ fn check_action_reference(
             line_number,
             step_indent,
             credentials_disabled: false,
-            unsafe_checkout_enabled: false,
         });
     }
 
@@ -420,9 +402,6 @@ fn finish_checkout_step(
             checkout.line_number
         ));
     }
-    if checkout.unsafe_checkout_enabled {
-        return;
-    }
 }
 
 fn contains_yaml_indirection(line: &str) -> bool {
@@ -439,14 +418,18 @@ fn contains_yaml_indirection(line: &str) -> bool {
     }
 
     let raw_value = value.trim_start();
-    if raw_value.starts_with(['\'', '"']) {
+    if matches!(raw_value.as_bytes().first(), Some(b'\'' | b'"')) {
         return false;
     }
 
-    raw_value
-        .trim_start_matches(['[', '{', ','])
-        .trim_start()
-        .starts_with(['*', '&'])
+    matches!(
+        raw_value
+            .trim_start_matches(['[', '{', ','])
+            .trim_start()
+            .as_bytes()
+            .first(),
+        Some(b'*' | b'&')
+    )
 }
 
 fn strip_yaml_comment(line: &str) -> &str {
@@ -575,7 +558,7 @@ jobs:
 "#;
         let mut failures = Vec::new();
         check_workflow_content("anchors.yml", workflow, &mut failures);
-        assert_eq!(failures.len(), 3, "{failures:?}");
+        assert_eq!(failures.len(), 4, "{failures:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reject every `write` permission scope, including inline and job-level maps, rather than special-casing repository contents.
- Allow only the repository's approved trigger set and reject event surfaces that can execute from comments, external dispatches, workflow completions, or privileged pull-request context.
- Reject YAML anchors, aliases, and merge keys so policy checks cannot be obscured through indirection.
- Track checkout steps without confusing nested list values for new steps.
- Require `persist-credentials: false` and reject unsafe pull-request checkout mode.
- Require lowercase immutable GitHub Action SHAs and Docker SHA-256 digests.
- Add regression coverage for safe nested checkout configuration and each rejected trust boundary.

## Verification

- Protected `Repository smoke test` required before merge.
- The Rust 1.97.1 gate runs formatting, compilation, strict Clippy, tests, documentation, and the repository doctor.

## Risk / Notes

- This intentionally keeps workflows read-only and narrows allowed event surfaces.
- A future workflow needing a different trigger or token permission must change the policy and tests explicitly rather than inheriting authority by accident.
- No dependency or runtime permission was added.
