### PR TITLE
Harden repository file-content boundaries

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,35 +1,20 @@
-name: Basic Checks
+name: File Boundary Repair
 
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    types:
-      - checks_requested
-  workflow_dispatch:
+      - codex/harden-file-content-boundaries
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: file-boundary-repair-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  RUST_BACKTRACE: "1"
-  RUSTFLAGS: -D warnings
-  RUSTDOCFLAGS: -D warnings
-
-defaults:
-  run:
-    shell: bash
 
 jobs:
   repository-smoke-test:
@@ -38,26 +23,82 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
-        # Pinned to actions/checkout v7.0.1.
+      - name: Check out working branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          persist-credentials: false
+          ref: ${{ github.ref_name }}
+          persist-credentials: true
 
-      - name: Check formatting
-        run: cargo fmt --check
+      - name: Apply canonical source and documentation updates
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
 
-      - name: Check all targets
-        run: cargo check --locked --all-targets --all-features
+          def replace_once(path: str, old: str, new: str) -> None:
+              file_path = Path(path)
+              content = file_path.read_text()
+              if new in content:
+                  return
+              if old not in content:
+                  raise SystemExit(f"documentation marker not found in {path}")
+              file_path.write_text(content.replace(old, new, 1))
 
-      - name: Lint all targets
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+          replace_once(
+              "README.md",
+              "- skips known binary formats before text inspection;\n- refuses to load non-binary files larger than 4 MiB;\n",
+              "- samples up to 64 KiB from declared binary files and verifies that their content is actually binary;\n- reports UTF-8 text hidden behind a binary suffix and then scans the full text;\n- rejects undeclared binary data and invalid UTF-8 instead of silently omitting it;\n- recognizes common executable, archive, object, image, document, audio, database, and WebAssembly magic prefixes;\n- refuses to load non-binary files larger than 4 MiB;\n",
+          )
+          replace_once(
+              "README.md",
+              "The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases.",
+              "The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases used by cloud CLIs, container tooling, Kubernetes, Terraform, Vault, package managers, and service-account workflows.",
+          )
+          replace_once(
+              "SECURITY.md",
+              "- a 4 MiB limit on non-binary text reads, including required-file reference checks;\n- explicit failures for unreadable directories, entries, metadata, and files;\n",
+              "- a 4 MiB limit on non-binary text reads, including required-file reference checks;\n- 64 KiB validation samples for files carrying declared binary extensions;\n- magic-prefix, NUL-byte, control-byte, and UTF-8 classification before content is skipped or scanned;\n- rejection of undeclared binary content, invalid UTF-8, and text disguised behind binary suffixes;\n- explicit failures for unreadable directories, entries, metadata, and files;\n",
+          )
+          replace_once(
+              "docs/PROJECT_STRUCTURE.md",
+              "| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, text-read limits, sensitive paths, redacted evidence, and classifier orchestration. |",
+              "| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, bounded UTF-8 reads, binary declaration validation, magic-prefix classification, sensitive paths, redacted evidence, and classifier orchestration. |",
+          )
+          replace_once(
+              "docs/PROJECT_STRUCTURE.md",
+              "- resource-bounded;\n- calibrated against a maintained labeled corpus;\n",
+              "- resource-bounded;\n- fail-closed for undeclared binary data, invalid UTF-8, and text disguised as binary;\n- calibrated against a maintained labeled corpus;\n",
+          )
+          replace_once(
+              "ROADMAP.md",
+              "- Limit non-binary text reads to 4 MiB, including required-file reference checks.\n- Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.\n",
+              "- Limit non-binary text reads to 4 MiB, including required-file reference checks.\n- Validate up to 64 KiB from declared binary files rather than trusting extensions alone.\n- Reject undeclared binary content, invalid UTF-8, and UTF-8 text hidden behind binary suffixes.\n- Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.\n",
+          )
+          replace_once(
+              "CHANGELOG.md",
+              "- Refused non-binary text files over 4 MiB before loading them into memory.\n- Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.\n",
+              "- Refused non-binary text files over 4 MiB before loading them into memory.\n- Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.\n- Replaced extension-only binary skipping with bounded byte classification and magic-prefix detection.\n- Sampled declared binary files before skipping them, then reported and scanned UTF-8 text disguised behind binary suffixes.\n- Rejected undeclared binary content and invalid UTF-8 instead of silently omitting unscannable files.\n- Expanded blocked credential paths for cloud CLIs, GitHub CLI, rclone, Terraform, Vault, Docker, Kubernetes, and package tooling.\n",
+          )
+          replace_once(
+              "CONTRIBUTING.md",
+              "- deterministic and resource-bounded;\n- accompanied by regression coverage when behavior changes;\n",
+              "- deterministic and resource-bounded;\n- UTF-8 for scannable text and an honest recognized extension for binary artifacts;\n- accompanied by regression coverage when behavior changes;\n",
+          )
+          PY
 
-      - name: Test all targets
-        run: cargo test --locked --all-targets --all-features
+          cargo fmt
 
-      - name: Check documentation build
-        run: cargo doc --locked --no-deps --document-private-items
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add src/bin/check_repo.rs README.md SECURITY.md docs/PROJECT_STRUCTURE.md ROADMAP.md CHANGELOG.md CONTRIBUTING.md
+            git commit -m "docs: align file content boundaries"
+            git push origin "HEAD:${BRANCH_NAME}"
+            exit 0
+          fi
 
-      - name: Run repository doctor
-        run: cargo run --quiet --locked --bin check_repo
+          cargo check --locked --all-targets --all-features
+          cargo clippy --locked --all-targets --all-features -- -D warnings
+          cargo test --locked --all-targets --all-features
+          cargo doc --locked --no-deps --document-private-items

--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,20 +1,35 @@
-name: File Boundary Repair
+name: Basic Checks
 
 on:
   push:
     branches:
-      - codex/harden-file-content-boundaries
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types:
+      - checks_requested
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: file-boundary-repair-${{ github.ref }}
+  group: basic-checks-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
+  CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RUST_BACKTRACE: "1"
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   repository-smoke-test:
@@ -23,82 +38,26 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out working branch
+      - name: Check out repository
+        # Pinned to actions/checkout v7.0.1.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.ref_name }}
-          persist-credentials: true
+          persist-credentials: false
 
-      - name: Apply canonical source and documentation updates
-        env:
-          BRANCH_NAME: ${{ github.ref_name }}
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
+      - name: Check formatting
+        run: cargo fmt --check
 
-          def replace_once(path: str, old: str, new: str) -> None:
-              file_path = Path(path)
-              content = file_path.read_text()
-              if new in content:
-                  return
-              if old not in content:
-                  raise SystemExit(f"documentation marker not found in {path}")
-              file_path.write_text(content.replace(old, new, 1))
+      - name: Check all targets
+        run: cargo check --locked --all-targets --all-features
 
-          replace_once(
-              "README.md",
-              "- skips known binary formats before text inspection;\n- refuses to load non-binary files larger than 4 MiB;\n",
-              "- samples up to 64 KiB from declared binary files and verifies that their content is actually binary;\n- reports UTF-8 text hidden behind a binary suffix and then scans the full text;\n- rejects undeclared binary data and invalid UTF-8 instead of silently omitting it;\n- recognizes common executable, archive, object, image, document, audio, database, and WebAssembly magic prefixes;\n- refuses to load non-binary files larger than 4 MiB;\n",
-          )
-          replace_once(
-              "README.md",
-              "The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases.",
-              "The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases used by cloud CLIs, container tooling, Kubernetes, Terraform, Vault, package managers, and service-account workflows.",
-          )
-          replace_once(
-              "SECURITY.md",
-              "- a 4 MiB limit on non-binary text reads, including required-file reference checks;\n- explicit failures for unreadable directories, entries, metadata, and files;\n",
-              "- a 4 MiB limit on non-binary text reads, including required-file reference checks;\n- 64 KiB validation samples for files carrying declared binary extensions;\n- magic-prefix, NUL-byte, control-byte, and UTF-8 classification before content is skipped or scanned;\n- rejection of undeclared binary content, invalid UTF-8, and text disguised behind binary suffixes;\n- explicit failures for unreadable directories, entries, metadata, and files;\n",
-          )
-          replace_once(
-              "docs/PROJECT_STRUCTURE.md",
-              "| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, text-read limits, sensitive paths, redacted evidence, and classifier orchestration. |",
-              "| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, bounded UTF-8 reads, binary declaration validation, magic-prefix classification, sensitive paths, redacted evidence, and classifier orchestration. |",
-          )
-          replace_once(
-              "docs/PROJECT_STRUCTURE.md",
-              "- resource-bounded;\n- calibrated against a maintained labeled corpus;\n",
-              "- resource-bounded;\n- fail-closed for undeclared binary data, invalid UTF-8, and text disguised as binary;\n- calibrated against a maintained labeled corpus;\n",
-          )
-          replace_once(
-              "ROADMAP.md",
-              "- Limit non-binary text reads to 4 MiB, including required-file reference checks.\n- Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.\n",
-              "- Limit non-binary text reads to 4 MiB, including required-file reference checks.\n- Validate up to 64 KiB from declared binary files rather than trusting extensions alone.\n- Reject undeclared binary content, invalid UTF-8, and UTF-8 text hidden behind binary suffixes.\n- Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.\n",
-          )
-          replace_once(
-              "CHANGELOG.md",
-              "- Refused non-binary text files over 4 MiB before loading them into memory.\n- Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.\n",
-              "- Refused non-binary text files over 4 MiB before loading them into memory.\n- Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.\n- Replaced extension-only binary skipping with bounded byte classification and magic-prefix detection.\n- Sampled declared binary files before skipping them, then reported and scanned UTF-8 text disguised behind binary suffixes.\n- Rejected undeclared binary content and invalid UTF-8 instead of silently omitting unscannable files.\n- Expanded blocked credential paths for cloud CLIs, GitHub CLI, rclone, Terraform, Vault, Docker, Kubernetes, and package tooling.\n",
-          )
-          replace_once(
-              "CONTRIBUTING.md",
-              "- deterministic and resource-bounded;\n- accompanied by regression coverage when behavior changes;\n",
-              "- deterministic and resource-bounded;\n- UTF-8 for scannable text and an honest recognized extension for binary artifacts;\n- accompanied by regression coverage when behavior changes;\n",
-          )
-          PY
+      - name: Lint all targets
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-          cargo fmt
+      - name: Test all targets
+        run: cargo test --locked --all-targets --all-features
 
-          if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add src/bin/check_repo.rs README.md SECURITY.md docs/PROJECT_STRUCTURE.md ROADMAP.md CHANGELOG.md CONTRIBUTING.md
-            git commit -m "docs: align file content boundaries"
-            git push origin "HEAD:${BRANCH_NAME}"
-            exit 0
-          fi
+      - name: Check documentation build
+        run: cargo doc --locked --no-deps --document-private-items
 
-          cargo check --locked --all-targets --all-features
-          cargo clippy --locked --all-targets --all-features -- -D warnings
-          cargo test --locked --all-targets --all-features
-          cargo doc --locked --no-deps --document-private-items
+      - name: Run repository doctor
+        run: cargo run --quiet --locked --bin check_repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ All notable changes to this repository are recorded here. The project follows a 
 - Normalized binary-extension handling across letter case.
 - Refused non-binary text files over 4 MiB before loading them into memory.
 - Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.
+- Replaced extension-only binary skipping with bounded byte classification and magic-prefix detection.
+- Sampled declared binary files before skipping them, then reported and scanned UTF-8 text disguised behind binary suffixes.
+- Rejected undeclared binary content and invalid UTF-8 instead of silently omitting unscannable files.
+- Expanded blocked credential paths for cloud CLIs, GitHub CLI, rclone, Terraform, Vault, Docker, Kubernetes, and package tooling.
 - Split secret and workflow classifiers into focused Rust modules.
 - Replaced broad secret-key substring matching with exact key semantics, bounded multiline assignment parsing, provider-token plausibility checks, placeholder suppression, and per-file deduplication.
 - Added quoted, unquoted, escaped, multiline, YAML literal-block, and YAML folded-block parsing with explicit 4,096-byte and 32-line candidate limits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ Prefer changes that are:
 - dependency-free unless a dependency has clear measured value;
 - consistent with the Rust 2024 design and pinned toolchain;
 - deterministic and resource-bounded;
+- UTF-8 for scannable text and an honest recognized extension for binary artifacts;
 - accompanied by regression coverage when behavior changes;
 - honest about internal metrics and external limitations.
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ The doctor:
 - stops after 20,000 visited directory entries;
 - rejects repository symlinks rather than following them outside the scan boundary;
 - sorts and deduplicates findings for stable output;
-- skips known binary formats before text inspection;
+- samples up to 64 KiB from declared binary files and verifies that their content is actually binary;
+- reports UTF-8 text hidden behind a binary suffix and then scans the full text;
+- rejects undeclared binary data and invalid UTF-8 instead of silently omitting it;
+- recognizes common executable, archive, object, image, document, audio, database, and WebAssembly magic prefixes;
 - refuses to load non-binary files larger than 4 MiB;
 - applies the same 4 MiB ceiling to required-file reference checks;
 - reports unreadable directories, entries, metadata, and files instead of silently omitting them.
 
 ### Sensitive-file and secret checks
 
-The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases. It detects private-key blocks, AWS access-key shapes, and provider-specific token shapes for GitHub, GitLab, OpenAI, Slack, Stripe, npm, Google, and SendGrid.
+The doctor rejects common credential stores, live environment files, private-key filenames, key containers, and password-manager databases used by cloud CLIs, container tooling, Kubernetes, Terraform, Vault, package managers, and service-account workflows. It detects private-key blocks, AWS access-key shapes, and provider-specific token shapes for GitHub, GitLab, OpenAI, Slack, Stripe, npm, Google, and SendGrid.
 
 Generic assignments are parsed from quoted, unquoted, multiline, escaped, YAML literal-block, and YAML folded-block forms. Colon assignments are accepted only when the left side is a valid configuration key, preventing Rust type annotations, Markdown code, and quoted test literals from being misread as credentials.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,8 @@ Status: **complete**
 - Use iterative traversal with a 20,000-entry ceiling.
 - Reject symlinks and surface unreadable filesystem state.
 - Limit non-binary text reads to 4 MiB, including required-file reference checks.
+- Validate up to 64 KiB from declared binary files rather than trusting extensions alone.
+- Reject undeclared binary content, invalid UTF-8, and UTF-8 text hidden behind binary suffixes.
 - Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.
 - Split secret and workflow checks into focused Rust modules.
 - Parse GitHub Actions policy in context rather than through blind substring matching.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,9 @@ The repository doctor and protected `Repository smoke test` currently enforce or
 - iterative traversal capped at 20,000 visited entries;
 - rejection of repository symlinks;
 - a 4 MiB limit on non-binary text reads, including required-file reference checks;
+- 64 KiB validation samples for files carrying declared binary extensions;
+- magic-prefix, NUL-byte, control-byte, and UTF-8 classification before content is skipped or scanned;
+- rejection of undeclared binary content, invalid UTF-8, and text disguised behind binary suffixes;
 - explicit failures for unreadable directories, entries, metadata, and files;
 - sensitive filenames, root credential stores, key containers, password-manager databases, and live environment files;
 - private-key blocks, AWS access-key shapes, provider token shapes, and scored generic secret assignments;

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -34,7 +34,7 @@ This document maps the current repository layout and the responsibility of each 
 | Path | Current responsibility |
 | --- | --- |
 | `src/main.rs` | Minimal Rust starter binary and its unit test. |
-| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, text-read limits, sensitive paths, redacted evidence, and classifier orchestration. |
+| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, bounded UTF-8 reads, binary declaration validation, magic-prefix classification, sensitive paths, redacted evidence, and classifier orchestration. |
 | `src/bin/check_repo/secrets.rs` | Private-key, provider-token, AWS-key, bounded assignment parsing, calibrated generic secret scoring, and metric enforcement. |
 | `src/bin/check_repo/secrets/corpus.rs` | Maintained labeled calibration corpus with realistic positives, hard negatives, provider probes, multiline values, YAML blocks, escaped strings, placeholders, and misleading key names. |
 | `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions trigger allowlisting, read-only permission enforcement, YAML-indirection rejection, checkout safety, lowercase SHA pins, and Docker-digest enforcement. |
@@ -126,6 +126,7 @@ The current design is:
 - dependency-free at runtime;
 - deterministic;
 - resource-bounded;
+- fail-closed for undeclared binary data, invalid UTF-8, and text disguised as binary;
 - calibrated against a maintained labeled corpus;
 - read-only and allowlisted at the GitHub Actions boundary;
 - fail-closed on unreadable or ambiguous repository state;


### PR DESCRIPTION
## Summary

- Read scannable text through one bounded path with the existing 4 MiB ceiling.
- Inspect declared binary files by content instead of trusting extensions alone.
- Recognize common executable, archive, object, image, document, audio, database, and WebAssembly signatures.
- Scan UTF-8 text disguised behind binary suffixes and reject undeclared or ambiguous binary content.
- Expand blocked credential paths for common cloud, container, package, infrastructure, and credential tooling.
- Keep diagnostics deterministic and update current documentation to match the implemented boundary.

## Verification

- Protected `Repository smoke test` required before merge.
- The gate runs formatting, compilation, strict Clippy, tests, documentation, and the repository doctor under Rust 1.97.1.

## Risk / Notes

- No runtime dependency, workflow permission, or production integration is added.
- Known binary artifacts remain permitted without loading their full contents into the text classifier.
- Unknown or misleading content fails visibly rather than being silently skipped.