### PR TITLE
Add structured repository diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Documentation reconciled through **2026-08-16**.
+Documentation reconciled through **2026-08-17**.
 
 All notable changes to this repository are recorded here. The project follows a simple chronological changelog rather than a formal release-management process.
 
@@ -28,6 +28,9 @@ All notable changes to this repository are recorded here. The project follows a 
 - Dedicated test-only classifier corpus with realistic positives, hard negatives, provider probes, multiline assignments, YAML blocks, escaped values, documentation examples, placeholders, and misleading key names.
 - Calibration gates for average precision, precision, recall, and F1 at the active classifier threshold.
 - Workflow-policy regression tests for read-only permissions, trigger allowlisting, YAML indirection, checkout safety, nested inputs, and immutable references.
+- Focused content-classification module for bounded UTF-8 reads, declared-binary validation, magic-prefix recognition, and fail-closed handling.
+- Focused output module with deterministic text, JSON, and GitHub Actions annotation formats.
+- Command-line `--format` selection and `--help` for the repository doctor.
 
 ### Changed
 
@@ -45,13 +48,13 @@ All notable changes to this repository are recorded here. The project follows a 
 - Replaced recursive filesystem walking with iterative traversal capped at 20,000 visited entries.
 - Rejected repository symlinks instead of silently omitting them from the security boundary.
 - Normalized binary-extension handling across letter case.
-- Refused non-binary text files over 4 MiB before loading them into memory.
+- Refused scannable text files over 4 MiB before loading them into memory.
 - Applied the same 4 MiB ceiling to required-file reference checks and surfaced metadata failures explicitly.
 - Replaced extension-only binary skipping with bounded byte classification and magic-prefix detection.
 - Sampled declared binary files before skipping them, then reported and scanned UTF-8 text disguised behind binary suffixes.
 - Rejected undeclared binary content and invalid UTF-8 instead of silently omitting unscannable files.
 - Expanded blocked credential paths for cloud CLIs, GitHub CLI, rclone, Terraform, Vault, Docker, Kubernetes, and package tooling.
-- Split secret and workflow classifiers into focused Rust modules.
+- Split content, secret, workflow, and output responsibilities into focused Rust modules.
 - Replaced broad secret-key substring matching with exact key semantics, bounded multiline assignment parsing, provider-token plausibility checks, placeholder suppression, and per-file deduplication.
 - Added quoted, unquoted, escaped, multiline, YAML literal-block, and YAML folded-block parsing with explicit 4,096-byte and 32-line candidate limits.
 - Expanded provider coverage to current GitHub, GitLab, OpenAI, Slack, Stripe, npm, Google, SendGrid, AWS access-key, and private-key signals.
@@ -68,9 +71,12 @@ All notable changes to this repository are recorded here. The project follows a 
 - Corrected checkout-step tracking so nested input lists do not terminate checkout policy validation.
 - Expanded the protected Rust gate to all targets and features, direct doctor execution, merge-queue groups, pushes to `main`, and manual dispatches.
 - Added concurrency that cancels superseded runs for the same pull request or ref.
+- Made the doctor select GitHub annotation output automatically when `GITHUB_ACTIONS=true` while preserving concise text output locally.
+- Added deterministic JSON findings with stable `path`, `line`, and `message` fields for machine consumers.
+- Normalized repository findings into structured diagnostics without changing the underlying fail-closed exit behavior.
 - Grouped routine Dependabot minor and patch updates by ecosystem on a fixed Europe/Lisbon schedule while leaving major updates isolated for review.
-- Made the repository doctor assert durable toolchain, CI, classifier, workflow, and Dependabot guarantees so later edits cannot silently remove the automation baseline.
-- Reconciled the roadmap with completed repository, workflow, automation, doctor, and classifier-calibration phases.
+- Made the repository doctor assert durable toolchain, CI, classifier, workflow, content, diagnostic, and Dependabot guarantees so later edits cannot silently remove the automation baseline.
+- Reconciled the roadmap with completed repository, workflow, automation, doctor, classifier-calibration, and structured-diagnostic phases.
 - Distinguished the `codex-issue-22773-assets` and `codex-issue-23192-assets` evidence bundles from software releases, package versions, supported builds, and compatibility commitments.
 - Reconciled security, support, contribution, conduct, funding, legal, disclaimer, and attribution documents with the implemented repository and evidence surfaces.
 - Replaced the lightweight pull request checklist with scope, verification, impact, documentation, rollback, and follow-up sections.
@@ -80,7 +86,7 @@ All notable changes to this repository are recorded here. The project follows a 
 
 ### Documentation
 
-- Reviewed every maintained current-state document against the repository as implemented on 2026-08-16.
+- Reviewed every maintained current-state document against the repository as implemented through 2026-08-17.
 - Corrected beginner instructions to use a branch and pull request rather than pushing routine work directly to protected `main`.
 - Replaced stale “basic check” descriptions with the current modular doctor, protected gate, merge-queue, concurrency, resource-bound, and dependency-automation behavior.
 - Added explicit review dates to current technical and policy documentation.
@@ -91,6 +97,8 @@ All notable changes to this repository are recorded here. The project follows a 
 - Updated the README, beginner map, local setup, workflow guide, and structure map for the exact Rust 2024 toolchain and six-step quality gate.
 - Replaced the classifier roadmap's “in progress” status with the implemented calibration contract and optional future maintenance direction.
 - Documented the workflow event allowlist, universal write-permission rejection, indirection ban, checkout safety rules, and lowercase immutable-reference contract.
+- Documented content classification and all three repository-doctor diagnostic formats.
+- Marked structured diagnostics complete and moved genuinely optional work into a separate future phase.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rust Staging Lab
 
-Documentation snapshot: **2026-08-16**.
+Documentation snapshot: **2026-08-17**.
 
-A compact Rust-first staging area for learning GitHub, repository automation, defensive tooling, and future CLI ideas. The repository is deliberately small, but its checks are real: protected CI, deterministic repository inspection, bounded filesystem work, contextual GitHub Actions policy checks, and a calibrated secret-signal classifier.
+A compact Rust-first staging area for learning GitHub, repository automation, defensive tooling, and future CLI ideas. The repository is deliberately small, but its checks are real: protected CI, deterministic repository inspection, bounded filesystem work, contextual GitHub Actions policy checks, calibrated secret-signal classification, and structured diagnostics.
 
 ## Current Snapshot
 
@@ -14,8 +14,10 @@ A compact Rust-first staging area for learning GitHub, repository automation, de
 | Runtime dependencies | None |
 | Default branch | Protected `main` |
 | Required check | `Repository smoke test` |
-| Doctor text-read limit | 4 MiB per non-binary file |
+| Doctor text-read limit | 4 MiB per scannable text file |
+| Doctor binary sample limit | 64 KiB per declared binary file |
 | Doctor traversal limit | 20,000 visited directory entries |
+| Diagnostic formats | text, JSON, GitHub Actions annotations |
 | Intended use | Learning, testing, and experimentation only |
 
 Public repository: <https://github.com/jjoanna2-debug/test-project-tbd>
@@ -34,6 +36,7 @@ This repository is used to practice and improve:
 - dependency-free repository inspection and policy enforcement;
 - secret-pattern classification with measurable regression tests;
 - safe GitHub Actions and Dependabot configuration;
+- deterministic human-readable and machine-readable diagnostics;
 - documentation, licensing, contribution, and public-repository hygiene.
 
 It is not a production system, commercial product, managed service, professional recommendation, security product, or operational dependency.
@@ -46,6 +49,8 @@ Cargo.lock
 rust-toolchain.toml
 src/main.rs
 src/bin/check_repo.rs
+src/bin/check_repo/content.rs
+src/bin/check_repo/output.rs
 src/bin/check_repo/secrets.rs
 src/bin/check_repo/secrets/corpus.rs
 src/bin/check_repo/workflows.rs
@@ -65,7 +70,7 @@ The manifest also denies debug macros, unfinished `todo!` paths, and `unimplemen
 
 ## Repository Doctor
 
-`src/bin/check_repo.rs` builds one deterministic repository inventory and coordinates focused classifiers. It exits successfully only when the repository satisfies its current structural, security, workflow, and automation invariants.
+`src/bin/check_repo.rs` builds one deterministic repository inventory and coordinates focused content, secret, workflow, and output modules. It exits successfully only when the repository satisfies its current structural, security, workflow, automation, and content invariants.
 
 ### Inventory and resource boundaries
 
@@ -80,7 +85,7 @@ The doctor:
 - reports UTF-8 text hidden behind a binary suffix and then scans the full text;
 - rejects undeclared binary data and invalid UTF-8 instead of silently omitting it;
 - recognizes common executable, archive, object, image, document, audio, database, and WebAssembly magic prefixes;
-- refuses to load non-binary files larger than 4 MiB;
+- refuses to load scannable text files larger than 4 MiB;
 - applies the same 4 MiB ceiling to required-file reference checks;
 - reports unreadable directories, entries, metadata, and files instead of silently omitting them.
 
@@ -133,7 +138,21 @@ Workflow checks are context-aware rather than blind substring searches. The doct
 - lowercase SHA-256 digests for Docker actions;
 - checkout-step tracking that remains correct when inputs contain nested YAML lists.
 
-A future workflow needing a different trigger or token permission must update the policy, tests, risk analysis, and current documentation explicitly. The repository does not inherit authority merely because a YAML key exists for it.
+A future workflow needing a different trigger or token permission must update the policy, tests, risk analysis, and current documentation explicitly.
+
+### Structured diagnostics
+
+The doctor supports three deterministic output modes:
+
+```bash
+cargo run --quiet --locked --bin check_repo -- --format text
+cargo run --quiet --locked --bin check_repo -- --format json
+cargo run --quiet --locked --bin check_repo -- --format github
+```
+
+`text` is the default locally. `json` emits stable `path`, `line`, and `message` fields for machine consumers. `github` emits GitHub Actions workflow-command annotations so failures appear on the relevant file and line when available. Inside GitHub Actions, the default automatically switches to annotation output.
+
+The command also supports `--help` and rejects unknown or ambiguous arguments rather than silently inventing behavior.
 
 ## Run Locally
 
@@ -154,7 +173,7 @@ Or run the local wrapper for the repository doctor:
 bash scripts/doctor.sh
 ```
 
-Passing doctor output:
+Passing local output:
 
 ```text
 Repository check passed.
@@ -170,11 +189,11 @@ The required `Repository smoke test` runs formatting, compilation, strict Clippy
 - merge-queue groups;
 - manual workflow dispatches.
 
-The workflow disables incremental compilation, treats compiler and rustdoc warnings as failures, forces current JavaScript Action runtime behavior, and uses the exact toolchain declared by the repository.
+The workflow disables incremental compilation, treats compiler and rustdoc warnings as failures, forces current JavaScript Action runtime behavior, and uses the exact toolchain declared by the repository. The repository doctor automatically emits GitHub annotations during Actions runs.
 
 New commits cancel older in-progress runs for the same pull request or ref. CI therefore validates the current revision rather than financing an archaeological survey of superseded commits.
 
-The doctor also asserts the important toolchain, workflow, and Dependabot settings. Removing merge-queue coverage, stale-run cancellation, all-target checks, documentation compilation, direct doctor execution, read-only workflow boundaries, immutable references, or grouped dependency-update policy causes the repository gate to fail.
+The doctor also asserts the important toolchain, workflow, classifier, content-boundary, and Dependabot settings. Removing merge-queue coverage, stale-run cancellation, all-target checks, documentation compilation, direct doctor execution, read-only workflow boundaries, immutable references, or grouped dependency-update policy causes the repository gate to fail.
 
 ## Dependency Automation
 
@@ -209,10 +228,10 @@ Use a branch and pull request for changes to `main`. The current workflow is doc
 
 The completed baseline does not require another framework or another folder of ceremony. Future work should begin only when a concrete consumer exists. Useful candidates include:
 
-- structured findings for CI annotations or machine consumption;
 - benchmarks for large-but-valid repositories within the existing resource limits;
 - reusable library boundaries if a second binary or caller appears;
 - corpus maintenance when provider formats or realistic hard negatives change;
+- configuration only when fixed policy is no longer sufficient;
 - dependencies only where measured value exceeds maintenance and supply-chain cost.
 
 See [ROADMAP.md](ROADMAP.md) for the completed phase status and optional direction.
@@ -237,7 +256,7 @@ The repository doctor and protected workflow are guardrails, not a security audi
 
 ## Funding Status
 
-No active GitHub funding provider is configured as of 2026-08-16. The placeholder `.github/FUNDING.yml` does not expose a Sponsor button or create sponsorship tiers, paid support, consulting, maintenance, priority, or service obligations.
+No active GitHub funding provider is configured as of 2026-08-17. The placeholder `.github/FUNDING.yml` does not expose a Sponsor button or create sponsorship tiers, paid support, consulting, maintenance, priority, or service obligations.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Status reviewed: **2026-08-16**.
+Status reviewed: **2026-08-17**.
 
 This roadmap records the repository's completed baseline and reserves future work for concrete use cases. Completed phases describe implemented, tested behavior. Optional phases are not commitments or unfinished obligations.
 
@@ -31,8 +31,10 @@ Status: **complete**
 - Validate pull requests and pushes to `main`.
 - Validate merge-queue groups and allow manual dispatches.
 - Cancel superseded runs for the same pull request or ref.
-- Pin third-party Actions to immutable commit SHAs.
+- Pin third-party Actions to immutable lowercase commit SHAs.
+- Require immutable lowercase SHA-256 digests for Docker actions.
 - Disable persisted checkout credentials and keep workflow permissions read-only.
+- Reject unapproved trigger surfaces and YAML authorization indirection.
 - Treat compiler, Clippy, and rustdoc warnings as failures.
 - Validate formatting, all targets and features, tests, documentation, and repository policy.
 
@@ -43,11 +45,12 @@ Status: **complete**
 - Build one deterministic repository inventory per run.
 - Use iterative traversal with a 20,000-entry ceiling.
 - Reject symlinks and surface unreadable filesystem state.
-- Limit non-binary text reads to 4 MiB, including required-file reference checks.
+- Limit scannable text reads to 4 MiB, including required-file reference checks.
 - Validate up to 64 KiB from declared binary files rather than trusting extensions alone.
+- Recognize common binary magic prefixes before skipping content.
 - Reject undeclared binary content, invalid UTF-8, and UTF-8 text hidden behind binary suffixes.
 - Validate required files, source invariants, redacted evidence paths, sensitive filenames, credential stores, and key containers.
-- Split secret and workflow checks into focused Rust modules.
+- Split content, secret, workflow, and output responsibilities into focused Rust modules.
 - Parse GitHub Actions policy in context rather than through blind substring matching.
 - Run the doctor locally and as part of the protected CI gate.
 
@@ -68,16 +71,29 @@ Status: **complete**
 
 These metrics protect regression behavior on the repository's maintained corpus. They are not claims about an external production dataset.
 
-## Phase 6 — Useful CLI Direction
+## Phase 6 — Structured Diagnostics
+
+Status: **complete**
+
+- Preserve concise human-readable output for local use.
+- Expose deterministic JSON findings with stable path, line, and message fields.
+- Emit native GitHub Actions error annotations for file- and line-aware CI diagnostics.
+- Select GitHub annotation output automatically inside GitHub Actions while keeping text as the local default.
+- Support explicit `--format text`, `--format json`, and `--format github` selection.
+- Provide `--help` and fail on unknown or ambiguous command-line arguments.
+- Escape JSON and GitHub workflow-command data correctly.
+- Keep output handling dependency-free and covered by unit tests.
+
+## Phase 7 — Optional Future Direction
 
 Status: **optional**
 
 Proceed only when a real consumer exists:
 
-- expose structured findings suitable for CI annotations or machine consumption;
-- separate reusable library code from binary entry points if a second consumer appears;
 - benchmark large-but-valid repositories within the existing resource ceilings;
+- separate reusable library code from binary entry points if a second consumer appears;
 - add configuration only when fixed policy is no longer sufficient;
+- extend the calibration corpus when provider formats or realistic hard negatives change;
 - evaluate dependencies only when measured value exceeds maintenance and supply-chain cost.
 
 ## Deliberate Non-Goals

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,6 +1,6 @@
 # GitHub Workflow
 
-Verified against the repository on **2026-08-16**.
+Verified against the repository on **2026-08-17**.
 
 This guide defines the current branch-to-merge workflow. The default branch is protected, the required check is named `Repository smoke test`, and the same gate also validates merge-queue groups and pushes to `main`.
 
@@ -42,6 +42,14 @@ cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo test --locked --all-targets --all-features
 cargo doc --locked --no-deps --document-private-items
 cargo run --quiet --locked --bin check_repo
+```
+
+The doctor supports explicit output formats when needed:
+
+```bash
+cargo run --quiet --locked --bin check_repo -- --format text
+cargo run --quiet --locked --bin check_repo -- --format json
+cargo run --quiet --locked --bin check_repo -- --format github
 ```
 
 The local wrapper remains available when only the doctor needs to be rerun:
@@ -100,6 +108,8 @@ The workflow currently runs on:
 
 The job has read-only repository contents permission, uses a full lowercase commit-SHA pin for `actions/checkout`, disables persisted checkout credentials, disables incremental compilation, and treats compiler and rustdoc warnings as failures. The repository toolchain file keeps local and hosted validation on the same exact Rust release.
 
+When `GITHUB_ACTIONS=true`, the repository doctor automatically selects GitHub annotation output. Findings with a parsed file and line become native workflow error annotations rather than anonymous log text. Explicit `--format github` remains available for local reproduction, while `--format json` provides deterministic machine-readable findings.
+
 ## 9. Workflow Security Contract
 
 Every workflow is scanned by the Rust repository doctor. The current contract is intentionally narrow:
@@ -119,13 +129,24 @@ Every workflow is scanned by the Rust repository doctor. The current contract is
 
 A future workflow requiring a new trigger or token permission must change the policy, regression tests, security documentation, and risk analysis in the same pull request. Authority is never inherited merely because YAML accepts it.
 
-## 10. Superseded Runs
+## 10. Content Boundary Contract
+
+Repository files are not trusted merely because their extensions look familiar. The doctor:
+
+- caps scannable text at 4 MiB;
+- samples at most 64 KiB from files carrying declared binary extensions;
+- recognizes common binary magic prefixes;
+- rejects undeclared binary data and invalid UTF-8;
+- reports and scans UTF-8 text hidden behind a binary suffix;
+- preserves bounded work instead of loading known binary artifacts wholesale.
+
+## 11. Superseded Runs
 
 The workflow concurrency key is based on the workflow plus the pull request number or Git ref. A newer commit cancels an older in-progress run for the same pull request or ref.
 
 A canceled obsolete run is not a quality failure. It means a newer revision has replaced it and will receive the authoritative result.
 
-## 11. Review Before Merge
+## 12. Review Before Merge
 
 Before merging:
 
@@ -135,12 +156,13 @@ Before merging:
 4. Confirm documentation matches the implemented behavior.
 5. Confirm no secrets, credentials, personal data, confidential information, or unredacted evidence entered the branch.
 6. Confirm workflow triggers and permissions remain within the repository contract.
+7. Confirm any binary artifact has an honest recognized extension and expected content.
 
-## 12. Merge Queue
+## 13. Merge Queue
 
 When the merge queue is used, GitHub creates a proposed merge-group commit and runs the same `Repository smoke test` against that combined state. This catches failures caused by interaction with newer `main` changes instead of trusting an earlier pull-request result.
 
-## 13. After Merge
+## 14. After Merge
 
 ```bash
 git switch main
@@ -165,7 +187,7 @@ The Rust toolchain is intentionally exact rather than floating. A toolchain upda
 
 ## Documentation Freshness
 
-Update documentation in the same pull request whenever behavior, commands, file layout, policy, supported tooling, automation, or roadmap status changes. Add or update the review date on current-state documents.
+Update documentation in the same pull request whenever behavior, commands, file layout, policy, supported tooling, automation, diagnostics, or roadmap status changes. Add or update the review date on current-state documents.
 
 A green build beside obsolete instructions is merely a well-tested lie.
 

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -1,8 +1,8 @@
 # Local Setup
 
-Verified against the repository on **2026-08-16**.
+Verified against the repository on **2026-08-17**.
 
-This guide covers the current local workflow: clone, create a branch, run the same validation used by CI, commit, push, and open a pull request.
+This guide covers the current local workflow: clone, create a branch, run the same validation used by CI, inspect repository-doctor diagnostics, commit, push, and open a pull request.
 
 ## Requirements
 
@@ -55,7 +55,10 @@ Cargo.toml
 rust-toolchain.toml
 src/main.rs
 src/bin/check_repo.rs
+src/bin/check_repo/content.rs
+src/bin/check_repo/output.rs
 src/bin/check_repo/secrets.rs
+src/bin/check_repo/secrets/corpus.rs
 src/bin/check_repo/workflows.rs
 README.md
 START_HERE.md
@@ -80,6 +83,30 @@ cargo run --quiet --locked --bin check_repo
 
 The repository treats compiler, Clippy, and rustdoc warnings as failures in CI. Fix the first reported defect, rerun the failed command, and then rerun the full set.
 
+## Repository Doctor Output
+
+The local default is human-readable text:
+
+```bash
+cargo run --quiet --locked --bin check_repo -- --format text
+```
+
+For deterministic machine-readable output:
+
+```bash
+cargo run --quiet --locked --bin check_repo -- --format json
+```
+
+For the same annotation format used in GitHub Actions:
+
+```bash
+cargo run --quiet --locked --bin check_repo -- --format github
+```
+
+Use `--help` for the supported interface. Unsupported or ambiguous arguments fail rather than being ignored.
+
+Inside GitHub Actions, the doctor automatically defaults to GitHub annotations. Locally it defaults to text.
+
 ## Run the Doctor Wrapper
 
 ```bash
@@ -88,17 +115,19 @@ bash scripts/doctor.sh
 
 The doctor currently checks:
 
-- required repository, toolchain, and source invariants;
+- required repository, toolchain, source, content, and output invariants;
 - one deterministic, sorted repository inventory;
 - iterative traversal capped at 20,000 visited entries;
 - rejection of symlinks and explicit reporting of unreadable filesystem state;
-- a 4 MiB ceiling on every non-binary text read, including required-file reference checks;
+- a 4 MiB ceiling on every scannable text read, including required-file reference checks;
+- up to 64 KiB of validation for files carrying declared binary extensions;
+- binary magic prefixes, UTF-8 validity, misleading binary suffixes, and undeclared binary content;
 - sensitive filenames, credential stores, key containers, and non-redacted evidence paths;
 - private-key blocks, provider token shapes, AWS access-key shapes, and scored generic secret assignments;
-- contextual GitHub Actions permissions, triggers, checkout credentials, full action SHA pins, and Docker digests;
-- durable CI and Dependabot configuration invariants.
+- contextual GitHub Actions permissions, triggers, YAML indirection, checkout credentials, full lowercase action SHA pins, and lowercase Docker digests;
+- durable CI, classifier, content, diagnostic, and Dependabot configuration invariants.
 
-Passing output:
+Passing wrapper output:
 
 ```text
 Repository check passed.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-Verified against `main` on **2026-08-16**.
+Verified against `main` on **2026-08-17**.
 
 This document maps the current repository layout and the responsibility of each maintained path.
 
@@ -8,7 +8,7 @@ This document maps the current repository layout and the responsibility of each 
 
 | Path | Current responsibility |
 | --- | --- |
-| `README.md` | Current project snapshot, architecture, checks, automation, priorities, evidence-release status, and boundaries. |
+| `README.md` | Current project snapshot, architecture, checks, automation, diagnostics, evidence-release status, and boundaries. |
 | `START_HERE.md` | Beginner map and safe first branch-to-PR exercise. |
 | `Cargo.toml` | Package metadata, version `0.1.0`, Edition 2024, Rust `1.97.1`, repository metadata, publish setting, and lint policy. |
 | `Cargo.lock` | Locked dependency state for reproducible local and CI commands. |
@@ -34,7 +34,9 @@ This document maps the current repository layout and the responsibility of each 
 | Path | Current responsibility |
 | --- | --- |
 | `src/main.rs` | Minimal Rust starter binary and its unit test. |
-| `src/bin/check_repo.rs` | Main repository-doctor binary: required-file policy, source invariants, iterative bounded inventory, bounded UTF-8 reads, binary declaration validation, magic-prefix classification, sensitive paths, redacted evidence, and classifier orchestration. |
+| `src/bin/check_repo.rs` | Main repository-doctor binary: CLI dispatch, required-file policy, source invariants, iterative bounded inventory, sensitive paths, redacted evidence, and classifier orchestration. |
+| `src/bin/check_repo/content.rs` | Bounded UTF-8 reads, declared-binary validation, binary sampling, magic-prefix classification, and fail-closed content handling. |
+| `src/bin/check_repo/output.rs` | Deterministic text, JSON, and GitHub Actions annotation output with CLI parsing and escaping. |
 | `src/bin/check_repo/secrets.rs` | Private-key, provider-token, AWS-key, bounded assignment parsing, calibrated generic secret scoring, and metric enforcement. |
 | `src/bin/check_repo/secrets/corpus.rs` | Maintained labeled calibration corpus with realistic positives, hard negatives, provider probes, multiline values, YAML blocks, escaped strings, placeholders, and misleading key names. |
 | `src/bin/check_repo/workflows.rs` | Context-aware GitHub Actions trigger allowlisting, read-only permission enforcement, YAML-indirection rejection, checkout safety, lowercase SHA pins, and Docker-digest enforcement. |
@@ -42,6 +44,18 @@ This document maps the current repository layout and the responsibility of each 
 The package has no runtime dependencies. `unsafe_code` is forbidden. Clippy `all` and `pedantic` are enabled, while debug macros and unfinished `todo!` or `unimplemented!` paths are denied. CI promotes warnings to failures.
 
 The classifier corpus is test-only. Provider-shaped probes are constructed at runtime so source control does not contain credential-like literals merely to exercise detection.
+
+## Content Boundary Contract
+
+The content classifier:
+
+- reads scannable text through a single bounded UTF-8 path;
+- caps text reads at 4 MiB;
+- samples at most 64 KiB from files carrying declared binary extensions;
+- recognizes common executable, archive, object, image, document, audio, database, font, and WebAssembly signatures;
+- rejects undeclared binary content and invalid UTF-8;
+- reports and scans UTF-8 text disguised behind a binary extension;
+- does not load an entire known binary artifact merely to establish that it is binary.
 
 ## Classifier Calibration Contract
 
@@ -69,12 +83,24 @@ The workflow classifier enforces:
 
 The policy rejects indirection rather than resolving it. Authorization remains visible, deterministic, and locally reviewable in each workflow file.
 
+## Diagnostic Contract
+
+The output module provides:
+
+- human-readable text output for local use;
+- deterministic JSON findings with path, line, and message fields;
+- native GitHub Actions error annotations;
+- automatic GitHub-format selection inside Actions;
+- explicit `--format text`, `--format json`, and `--format github` selection;
+- `--help` and strict rejection of unsupported arguments;
+- escaping for JSON strings and GitHub workflow-command properties.
+
 ## Documentation
 
 | Path | Current responsibility |
 | --- | --- |
-| `docs/LOCAL_SETUP.md` | Tool requirements, clone, branch, complete local gate, push, PR, and post-merge cleanup. |
-| `docs/GITHUB_WORKFLOW.md` | Protected branch-to-merge contract, exact toolchain, CI steps, event allowlist, read-only permissions, concurrency, merge queue, and dependency automation. |
+| `docs/LOCAL_SETUP.md` | Tool requirements, clone, branch, complete local gate, diagnostic formats, push, PR, and post-merge cleanup. |
+| `docs/GITHUB_WORKFLOW.md` | Protected branch-to-merge contract, exact toolchain, CI steps, annotations, event allowlist, read-only permissions, concurrency, merge queue, and dependency automation. |
 | `docs/PROJECT_STRUCTURE.md` | This current layout map. |
 
 ## Local Helper
@@ -89,7 +115,7 @@ CI runs the Rust doctor directly rather than placing a shell wrapper between Git
 
 | Path | Current responsibility |
 | --- | --- |
-| `.github/workflows/basic-checks.yml` | Required `Repository smoke test` for pull requests, pushes to `main`, merge groups, and manual dispatch; validates formatting, compilation, linting, tests, documentation, and repository policy with stale-run cancellation and read-only checkout. |
+| `.github/workflows/basic-checks.yml` | Required `Repository smoke test` for pull requests, pushes to `main`, merge groups, and manual dispatch; validates formatting, compilation, linting, tests, documentation, and repository policy with stale-run cancellation, read-only checkout, and annotated doctor findings. |
 | `.github/dependabot.yml` | Monday 06:00 Europe/Lisbon GitHub Actions and Cargo checks, grouped minor/patch updates, separate major updates, and PR limits. |
 | `.github/CODEOWNERS` | Default review visibility. |
 | `.github/PULL_REQUEST_TEMPLATE.md` | Pull request scope, verification, risk, documentation, and safety checklist. |
@@ -129,10 +155,11 @@ The current design is:
 - fail-closed for undeclared binary data, invalid UTF-8, and text disguised as binary;
 - calibrated against a maintained labeled corpus;
 - read-only and allowlisted at the GitHub Actions boundary;
+- structured for both human and machine-readable diagnostics;
 - fail-closed on unreadable or ambiguous repository state;
 - protected by CI;
-- self-enforcing for critical toolchain, workflow, classifier, and Dependabot invariants;
+- self-enforcing for critical toolchain, workflow, classifier, content, diagnostic, and Dependabot invariants;
 - explicit about the difference between internal regression metrics and external production claims;
 - explicit about the difference between evidence-asset tags and software releases.
 
-Update this file whenever a maintained path, toolchain, calibration contract, workflow trust boundary, release-asset bundle, or material responsibility is added, removed, renamed, or changed.
+Update this file whenever a maintained path, toolchain, calibration contract, content boundary, workflow trust boundary, diagnostic contract, release-asset bundle, or material responsibility is added, removed, renamed, or changed.

--- a/src/bin/check_repo.rs
+++ b/src/bin/check_repo.rs
@@ -3,15 +3,20 @@
 
 #![forbid(unsafe_code)]
 
+#[path = "check_repo/content.rs"]
+mod content;
+#[path = "check_repo/output.rs"]
+mod output;
 #[path = "check_repo/secrets.rs"]
 mod secrets;
 #[path = "check_repo/workflows.rs"]
 mod workflows;
 
+use content::{ScannableContent, read_repository_content, read_required_text};
+use output::{CliAction, OutputFormat, findings_from_raw};
 use secrets::check_secret_content;
 use std::env;
 use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use workflows::check_workflow_content;
@@ -24,6 +29,8 @@ const REQUIRED_FILES: &[&str] = &[
     "rust-toolchain.toml",
     "src/main.rs",
     "src/bin/check_repo.rs",
+    "src/bin/check_repo/content.rs",
+    "src/bin/check_repo/output.rs",
     "src/bin/check_repo/secrets.rs",
     "src/bin/check_repo/secrets/corpus.rs",
     "src/bin/check_repo/workflows.rs",
@@ -110,8 +117,26 @@ const SOURCE_REFERENCES: &[(&str, &[&str])] = &[
         "src/bin/check_repo.rs",
         &[
             "#![forbid(unsafe_code)]",
+            "check_repo/content.rs",
+            "check_repo/output.rs",
             "check_repo/secrets.rs",
             "check_repo/workflows.rs",
+        ],
+    ),
+    (
+        "src/bin/check_repo/content.rs",
+        &[
+            "pub(crate) fn read_repository_content",
+            "pub(crate) fn read_required_text",
+            "const BINARY_SAMPLE_BYTES",
+        ],
+    ),
+    (
+        "src/bin/check_repo/output.rs",
+        &[
+            "pub(crate) enum OutputFormat",
+            "pub(crate) struct Finding",
+            "pub(crate) fn render",
         ],
     ),
     (
@@ -155,23 +180,17 @@ const SKIPPED_DIRS: &[&str] = &[
     "temp",
     "worktrees",
 ];
-
-const BINARY_SUFFIXES: &[&str] = &[
-    "7z", "a", "avi", "bmp", "class", "dmg", "doc", "docx", "dylib", "eot", "exe", "flac", "gif",
-    "gz", "ico", "jar", "jpeg", "jpg", "m4a", "mov", "mp3", "mp4", "o", "otf", "pdf", "png", "ppt",
-    "pptx", "so", "tar", "tiff", "ttf", "wav", "webm", "webp", "woff", "woff2", "xls", "xlsx",
-    "zip",
-];
-const MAX_TEXT_FILE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_SCAN_ENTRIES: usize = 20_000;
 
 const BLOCKED_FILENAMES: &[&str] = &[
     ".env",
     ".env.local",
+    ".netrc",
     ".npmrc",
     ".pypirc",
-    ".netrc",
+    ".vault-token",
     "credentials.json",
+    "credentials.tfrc.json",
     "id_dsa",
     "id_ecdsa",
     "id_ed25519",
@@ -183,17 +202,42 @@ const BLOCKED_SECRET_SUFFIXES: &[&str] = &[".jks", ".key", ".kdbx", ".keystore",
 
 const BLOCKED_SENSITIVE_PATHS: &[&str] = &[
     ".aws/credentials",
+    ".azure/accesstokens.json",
+    ".azure/azureprofile.json",
     ".config/gcloud/application_default_credentials.json",
+    ".config/gh/hosts.yml",
+    ".config/rclone/rclone.conf",
     ".docker/config.json",
     ".kube/config",
+    ".terraform.d/credentials.tfrc.json",
 ];
 
 fn main() -> ExitCode {
+    let action = match output::parse_cli() {
+        Ok(action) => action,
+        Err(error) => {
+            eprintln!("{error}\n\n{}", output::help_text());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match action {
+        CliAction::Help => {
+            print!("{}", output::help_text());
+            ExitCode::SUCCESS
+        }
+        CliAction::Run(format) => run(format),
+    }
+}
+
+fn run(format: OutputFormat) -> ExitCode {
     let root = match env::current_dir() {
         Ok(path) => path,
         Err(error) => {
-            eprintln!("Repository check failed:");
-            eprintln!("- could not read current directory: {error}");
+            let findings = findings_from_raw([format!(
+                "repository: could not read current directory: {error}"
+            )]);
+            output::render(format, &findings);
             return ExitCode::FAILURE;
         }
     };
@@ -207,27 +251,25 @@ fn main() -> ExitCode {
     let repository_files = repo_files_under(&root, &root, &mut failures);
     check_repository_files(&root, &repository_files, &mut failures);
 
-    missing.sort_unstable();
-    missing.dedup();
-    failures.sort_unstable();
-    failures.dedup();
+    let mut raw_findings = missing;
+    raw_findings.extend(failures);
+    raw_findings.sort_unstable();
+    raw_findings.dedup();
 
-    if missing.is_empty() && failures.is_empty() {
-        println!("Repository check passed.");
-        return ExitCode::SUCCESS;
-    }
+    let findings = findings_from_raw(raw_findings);
+    output::render(format, &findings);
 
-    println!("Repository check failed:");
-    for item in missing.iter().chain(failures.iter()) {
-        println!("- {item}");
+    if findings.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
     }
-    ExitCode::FAILURE
 }
 
 fn check_required_files(root: &Path, missing: &mut Vec<String>) {
     for required_file in REQUIRED_FILES {
         if !root.join(required_file).is_file() {
-            missing.push((*required_file).to_owned());
+            missing.push(format!("{required_file}: required file is missing"));
         }
     }
 }
@@ -239,26 +281,17 @@ fn check_source_references(root: &Path, missing: &mut Vec<String>) {
             continue;
         }
 
-        match fs::metadata(&source_path) {
-            Ok(metadata) if is_oversized_text_file(metadata.len()) => {
-                missing.push(format!("{path} exceeds the 4 MiB text scan limit"));
-                continue;
-            }
-            Ok(_) => {}
+        let content = match read_required_text(&source_path, path) {
+            Ok(content) => content,
             Err(error) => {
-                missing.push(format!("{path} metadata could not be read: {error}"));
+                missing.push(error);
                 continue;
             }
-        }
-
-        let Ok(content) = fs::read_to_string(&source_path) else {
-            missing.push(format!("{path} must be readable as UTF-8"));
-            continue;
         };
 
         for expected in *expected_values {
             if !content.contains(expected) {
-                missing.push(format!("{path} reference: {expected}"));
+                missing.push(format!("{path}: missing required reference: {expected}"));
             }
         }
     }
@@ -271,44 +304,27 @@ fn check_repository_files(root: &Path, files: &[PathBuf], failures: &mut Vec<Str
         check_evidence_artifact(&relative_path, failures);
 
         if is_blocked_sensitive_path(&relative_path) {
-            failures.push(format!("{relative_path} is a blocked sensitive path"));
+            failures.push(format!("{relative_path}: blocked sensitive path"));
         }
 
         if let Some(file_name) = file_path.file_name().and_then(|name| name.to_str())
             && is_blocked_filename(file_name)
         {
-            failures.push(format!("{relative_path} is a blocked sensitive filename"));
+            failures.push(format!("{relative_path}: blocked sensitive filename"));
         }
 
-        if is_binary_file(file_path) {
-            continue;
-        }
-
-        match fs::metadata(file_path) {
-            Ok(metadata) if is_oversized_text_file(metadata.len()) => {
-                failures.push(format!("{relative_path} exceeds the 4 MiB text scan limit"));
-                continue;
-            }
-            Ok(_) => {}
-            Err(error) => {
-                failures.push(format!(
-                    "{relative_path} metadata could not be read: {error}"
-                ));
-                continue;
-            }
-        }
-
-        match fs::read_to_string(file_path) {
-            Ok(content) => {
+        match read_repository_content(file_path, &relative_path) {
+            Ok(ScannableContent::Binary) => {}
+            Ok(ScannableContent::Text { content, warning }) => {
+                if let Some(warning) = warning {
+                    failures.push(warning);
+                }
                 check_secret_content(&relative_path, &content, failures);
                 if is_workflow_file(&relative_path, file_path) {
                     check_workflow_content(&relative_path, &content, failures);
                 }
             }
-            Err(error) if error.kind() == io::ErrorKind::InvalidData => {}
-            Err(error) => {
-                failures.push(format!("{relative_path} could not be read: {error}"));
-            }
+            Err(error) => failures.push(error),
         }
     }
 }
@@ -323,7 +339,9 @@ fn check_evidence_artifact(relative_path: &str, failures: &mut Vec<String>) {
         || lower_path.contains("unredacted")
         || lower_path.contains("nonredacted")
     {
-        failures.push(format!("{relative_path} must be explicitly redacted"));
+        failures.push(format!(
+            "{relative_path}: evidence artifact must be explicitly redacted"
+        ));
     }
 }
 
@@ -337,7 +355,7 @@ fn repo_files_under(root: &Path, directory: &Path, failures: &mut Vec<String>) -
             Ok(entries) => entries,
             Err(error) => {
                 failures.push(format!(
-                    "{} could not be read: {error}",
+                    "{}: directory could not be read: {error}",
                     relative_path(root, &current_directory)
                 ));
                 continue;
@@ -348,7 +366,7 @@ fn repo_files_under(root: &Path, directory: &Path, failures: &mut Vec<String>) -
             scanned_entries += 1;
             if scanned_entries > MAX_SCAN_ENTRIES {
                 failures.push(format!(
-                    "repository scan exceeds the {MAX_SCAN_ENTRIES} entry limit"
+                    "repository: scan exceeds the {MAX_SCAN_ENTRIES} entry limit"
                 ));
                 directories.clear();
                 break;
@@ -356,7 +374,7 @@ fn repo_files_under(root: &Path, directory: &Path, failures: &mut Vec<String>) -
 
             let Ok(entry) = entry else {
                 failures.push(format!(
-                    "{} contains an unreadable directory entry",
+                    "{}: contains an unreadable directory entry",
                     relative_path(root, &current_directory)
                 ));
                 continue;
@@ -365,7 +383,7 @@ fn repo_files_under(root: &Path, directory: &Path, failures: &mut Vec<String>) -
             let path = entry.path();
             let Ok(file_type) = entry.file_type() else {
                 failures.push(format!(
-                    "{} file type could not be read",
+                    "{}: file type could not be read",
                     relative_path(root, &path)
                 ));
                 continue;
@@ -379,7 +397,7 @@ fn repo_files_under(root: &Path, directory: &Path, failures: &mut Vec<String>) -
                 files.push(path);
             } else if file_type.is_symlink() {
                 failures.push(format!(
-                    "{} is a symlink and will not be followed",
+                    "{}: symlink will not be followed",
                     relative_path(root, &path)
                 ));
             }
@@ -419,17 +437,6 @@ fn is_environment_template(file_name: &str) -> bool {
     )
 }
 
-fn is_binary_file(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase)
-        .is_some_and(|extension| BINARY_SUFFIXES.contains(&extension.as_str()))
-}
-
-fn is_oversized_text_file(size: u64) -> bool {
-    size > MAX_TEXT_FILE_BYTES
-}
-
 fn is_workflow_file(relative_path: &str, path: &Path) -> bool {
     relative_path.starts_with(".github/workflows/")
         && matches!(
@@ -450,10 +457,7 @@ fn relative_path(root: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        MAX_TEXT_FILE_BYTES, is_binary_file, is_blocked_filename, is_blocked_sensitive_path,
-        is_oversized_text_file, should_skip_dir,
-    };
+    use super::{is_blocked_filename, is_blocked_sensitive_path, should_skip_dir};
     use std::path::Path;
 
     #[test]
@@ -462,6 +466,7 @@ mod tests {
         assert!(is_blocked_filename("service-account.json"));
         assert!(is_blocked_filename("signing.P12"));
         assert!(is_blocked_filename("vault.kdbx"));
+        assert!(is_blocked_filename(".vault-token"));
         assert!(!is_blocked_filename(".env.example"));
         assert!(!is_blocked_filename(".env.production.sample"));
         assert!(!is_blocked_filename("public-certificate.pem"));
@@ -471,20 +476,8 @@ mod tests {
     fn blocks_root_credential_paths() {
         assert!(is_blocked_sensitive_path(".aws/credentials"));
         assert!(is_blocked_sensitive_path(".KUBE/config"));
+        assert!(is_blocked_sensitive_path(".config/gh/hosts.yml"));
         assert!(!is_blocked_sensitive_path("docs/.aws/credentials"));
-    }
-
-    #[test]
-    fn recognizes_binary_extensions_case_insensitively() {
-        assert!(is_binary_file(Path::new("archive.ZIP")));
-        assert!(is_binary_file(Path::new("fixture.DOCX")));
-        assert!(!is_binary_file(Path::new("README.md")));
-    }
-
-    #[test]
-    fn bounds_text_file_scans() {
-        assert!(!is_oversized_text_file(MAX_TEXT_FILE_BYTES));
-        assert!(is_oversized_text_file(MAX_TEXT_FILE_BYTES + 1));
     }
 
     #[test]

--- a/src/bin/check_repo/content.rs
+++ b/src/bin/check_repo/content.rs
@@ -30,8 +30,8 @@ pub(crate) fn read_required_text(path: &Path, display_path: &str) -> Result<Stri
         return Err(format!("{display_path}: exceeds the 4 MiB text scan limit"));
     }
 
-    let bytes = fs::read(path)
-        .map_err(|error| format!("{display_path}: could not be read: {error}"))?;
+    let bytes =
+        fs::read(path).map_err(|error| format!("{display_path}: could not be read: {error}"))?;
     String::from_utf8(bytes).map_err(|_| format!("{display_path}: must be readable as UTF-8"))
 }
 
@@ -104,8 +104,8 @@ fn read_sample(path: &Path) -> io::Result<Vec<u8>> {
 }
 
 fn read_full_text(path: &Path, display_path: &str) -> Result<String, String> {
-    let bytes = fs::read(path)
-        .map_err(|error| format!("{display_path}: could not be read: {error}"))?;
+    let bytes =
+        fs::read(path).map_err(|error| format!("{display_path}: could not be read: {error}"))?;
     String::from_utf8(bytes).map_err(|_| format!("{display_path}: must be readable as UTF-8"))
 }
 
@@ -186,9 +186,7 @@ fn has_known_binary_magic(bytes: &[u8]) -> bool {
         return true;
     }
 
-    bytes
-        .get(257..262)
-        .is_some_and(|magic| magic == b"ustar")
+    bytes.get(257..262).is_some_and(|magic| magic == b"ustar")
 }
 
 #[cfg(test)]
@@ -217,6 +215,9 @@ mod tests {
     fn distinguishes_text_binary_and_invalid_text() {
         assert_eq!(classify_sample(b"plain UTF-8 text\n"), SampleKind::Text);
         assert_eq!(classify_sample(b"abc\0def"), SampleKind::BinaryLike);
-        assert_eq!(classify_sample(&[b'a', 0xff, b'b']), SampleKind::InvalidText);
+        assert_eq!(
+            classify_sample(&[b'a', 0xff, b'b']),
+            SampleKind::InvalidText
+        );
     }
 }

--- a/src/bin/check_repo/content.rs
+++ b/src/bin/check_repo/content.rs
@@ -1,0 +1,230 @@
+// Copyright 2026 Jean-Claude Joanna
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::path::Path;
+
+pub(crate) const MAX_TEXT_FILE_BYTES: u64 = 4 * 1024 * 1024;
+const BINARY_SAMPLE_BYTES: usize = 64 * 1024;
+
+const BINARY_SUFFIXES: &[&str] = &[
+    "7z", "a", "avi", "bmp", "class", "dmg", "doc", "docx", "dylib", "eot", "exe", "flac", "gif",
+    "gz", "ico", "jar", "jpeg", "jpg", "m4a", "mov", "mp3", "mp4", "o", "otf", "pdf", "png", "ppt",
+    "pptx", "so", "sqlite", "sqlite3", "tar", "tiff", "ttf", "wav", "wasm", "webm", "webp", "woff",
+    "woff2", "xls", "xlsx", "zip",
+];
+
+pub(crate) enum ScannableContent {
+    Text {
+        content: String,
+        warning: Option<String>,
+    },
+    Binary,
+}
+
+pub(crate) fn read_required_text(path: &Path, display_path: &str) -> Result<String, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|error| format!("{display_path}: metadata could not be read: {error}"))?;
+    if metadata.len() > MAX_TEXT_FILE_BYTES {
+        return Err(format!("{display_path}: exceeds the 4 MiB text scan limit"));
+    }
+
+    let bytes = fs::read(path)
+        .map_err(|error| format!("{display_path}: could not be read: {error}"))?;
+    String::from_utf8(bytes).map_err(|_| format!("{display_path}: must be readable as UTF-8"))
+}
+
+pub(crate) fn read_repository_content(
+    path: &Path,
+    display_path: &str,
+) -> Result<ScannableContent, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|error| format!("{display_path}: metadata could not be read: {error}"))?;
+    let declared_binary = has_binary_suffix(path);
+
+    let sample = read_sample(path)
+        .map_err(|error| format!("{display_path}: could not be sampled: {error}"))?;
+    let sample_kind = classify_sample(&sample);
+
+    if declared_binary {
+        return classify_declared_binary(path, display_path, metadata.len(), sample_kind);
+    }
+
+    if matches!(sample_kind, SampleKind::KnownBinary | SampleKind::BinaryLike) {
+        return Err(format!(
+            "{display_path}: contains binary data without a recognized binary extension"
+        ));
+    }
+    if matches!(sample_kind, SampleKind::InvalidText) {
+        return Err(format!("{display_path}: must be readable as UTF-8"));
+    }
+    if metadata.len() > MAX_TEXT_FILE_BYTES {
+        return Err(format!("{display_path}: exceeds the 4 MiB text scan limit"));
+    }
+
+    Ok(ScannableContent::Text {
+        content: read_full_text(path, display_path)?,
+        warning: None,
+    })
+}
+
+fn classify_declared_binary(
+    path: &Path,
+    display_path: &str,
+    size: u64,
+    sample_kind: SampleKind,
+) -> Result<ScannableContent, String> {
+    match sample_kind {
+        SampleKind::KnownBinary | SampleKind::BinaryLike => Ok(ScannableContent::Binary),
+        SampleKind::InvalidText => Err(format!(
+            "{display_path}: uses a binary extension but contains invalid UTF-8 text-like data"
+        )),
+        SampleKind::Text => {
+            if size > MAX_TEXT_FILE_BYTES {
+                return Err(format!(
+                    "{display_path}: contains UTF-8 text behind a binary extension but exceeds the 4 MiB text scan limit"
+                ));
+            }
+            Ok(ScannableContent::Text {
+                content: read_full_text(path, display_path)?,
+                warning: Some(format!(
+                    "{display_path}: uses a binary extension but contains UTF-8 text; content was scanned"
+                )),
+            })
+        }
+    }
+}
+
+fn read_sample(path: &Path) -> io::Result<Vec<u8>> {
+    let mut sample = Vec::with_capacity(BINARY_SAMPLE_BYTES);
+    File::open(path)?
+        .take(BINARY_SAMPLE_BYTES as u64)
+        .read_to_end(&mut sample)?;
+    Ok(sample)
+}
+
+fn read_full_text(path: &Path, display_path: &str) -> Result<String, String> {
+    let bytes = fs::read(path)
+        .map_err(|error| format!("{display_path}: could not be read: {error}"))?;
+    String::from_utf8(bytes).map_err(|_| format!("{display_path}: must be readable as UTF-8"))
+}
+
+fn has_binary_suffix(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|extension| BINARY_SUFFIXES.contains(&extension.as_str()))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SampleKind {
+    Text,
+    KnownBinary,
+    BinaryLike,
+    InvalidText,
+}
+
+fn classify_sample(sample: &[u8]) -> SampleKind {
+    if has_known_binary_magic(sample) {
+        return SampleKind::KnownBinary;
+    }
+    if looks_binary(sample) {
+        return SampleKind::BinaryLike;
+    }
+    if std::str::from_utf8(sample).is_ok() {
+        SampleKind::Text
+    } else {
+        SampleKind::InvalidText
+    }
+}
+
+fn looks_binary(sample: &[u8]) -> bool {
+    if sample.is_empty() {
+        return false;
+    }
+    if sample.contains(&0) {
+        return true;
+    }
+
+    let controls = sample
+        .iter()
+        .filter(|byte| **byte < 0x20 && !matches!(**byte, b'\n' | b'\r' | b'\t' | 0x0c))
+        .count();
+    controls.saturating_mul(20) > sample.len()
+}
+
+fn has_known_binary_magic(bytes: &[u8]) -> bool {
+    const PREFIXES: &[&[u8]] = &[
+        b"%PDF-",
+        b"\x89PNG\r\n\x1a\n",
+        b"GIF87a",
+        b"GIF89a",
+        b"PK\x03\x04",
+        b"PK\x05\x06",
+        b"PK\x07\x08",
+        b"\x1f\x8b",
+        b"7z\xbc\xaf'\x1c",
+        b"\x7fELF",
+        b"MZ",
+        b"\0asm",
+        b"SQLite format 3\0",
+        b"\xca\xfe\xba\xbe",
+        b"OTTO",
+        b"RIFF",
+        b"ID3",
+        b"fLaC",
+        b"OggS",
+    ];
+    if PREFIXES.iter().any(|prefix| bytes.starts_with(prefix)) {
+        return true;
+    }
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return true;
+    }
+    if bytes.starts_with(&[0x00, 0x01, 0x00, 0x00]) {
+        return true;
+    }
+    if bytes.len() > 262 && bytes.get(257..262) == Some(b"ustar") {
+        return true;
+    }
+
+    matches!(
+        bytes.get(..4),
+        Some([0xfe, 0xed, 0xfa, 0xce]
+            | [0xfe, 0xed, 0xfa, 0xcf]
+            | [0xce, 0xfa, 0xed, 0xfe]
+            | [0xcf, 0xfa, 0xed, 0xfe]
+            | [0xca, 0xfe, 0xba, 0xbe])
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SampleKind, classify_sample, has_binary_suffix};
+    use std::path::Path;
+
+    #[test]
+    fn recognizes_binary_extensions_case_insensitively() {
+        assert!(has_binary_suffix(Path::new("archive.ZIP")));
+        assert!(has_binary_suffix(Path::new("module.WASM")));
+        assert!(!has_binary_suffix(Path::new("README.md")));
+    }
+
+    #[test]
+    fn classifies_common_binary_signatures() {
+        assert_eq!(classify_sample(b"%PDF-1.7\n"), SampleKind::KnownBinary);
+        assert_eq!(
+            classify_sample(b"\x89PNG\r\n\x1a\nrest"),
+            SampleKind::KnownBinary
+        );
+        assert_eq!(classify_sample(b"PK\x03\x04rest"), SampleKind::KnownBinary);
+    }
+
+    #[test]
+    fn distinguishes_text_binary_and_invalid_text() {
+        assert_eq!(classify_sample(b"plain UTF-8 text\n"), SampleKind::Text);
+        assert_eq!(classify_sample(b"abc\0def"), SampleKind::BinaryLike);
+        assert_eq!(classify_sample(&[b'a', 0xff, b'b']), SampleKind::InvalidText);
+    }
+}

--- a/src/bin/check_repo/content.rs
+++ b/src/bin/check_repo/content.rs
@@ -51,22 +51,21 @@ pub(crate) fn read_repository_content(
         return classify_declared_binary(path, display_path, metadata.len(), sample_kind);
     }
 
-    if matches!(sample_kind, SampleKind::KnownBinary | SampleKind::BinaryLike) {
-        return Err(format!(
+    match sample_kind {
+        SampleKind::KnownBinary | SampleKind::BinaryLike => Err(format!(
             "{display_path}: contains binary data without a recognized binary extension"
-        ));
+        )),
+        SampleKind::InvalidText => Err(format!("{display_path}: must be readable as UTF-8")),
+        SampleKind::Text => {
+            if metadata.len() > MAX_TEXT_FILE_BYTES {
+                return Err(format!("{display_path}: exceeds the 4 MiB text scan limit"));
+            }
+            Ok(ScannableContent::Text {
+                content: read_full_text(path, display_path)?,
+                warning: None,
+            })
+        }
     }
-    if matches!(sample_kind, SampleKind::InvalidText) {
-        return Err(format!("{display_path}: must be readable as UTF-8"));
-    }
-    if metadata.len() > MAX_TEXT_FILE_BYTES {
-        return Err(format!("{display_path}: exceeds the 4 MiB text scan limit"));
-    }
-
-    Ok(ScannableContent::Text {
-        content: read_full_text(path, display_path)?,
-        warning: None,
-    })
 }
 
 fn classify_declared_binary(
@@ -170,6 +169,10 @@ fn has_known_binary_magic(bytes: &[u8]) -> bool {
         b"\0asm",
         b"SQLite format 3\0",
         b"\xca\xfe\xba\xbe",
+        b"\xfe\xed\xfa\xce",
+        b"\xfe\xed\xfa\xcf",
+        b"\xce\xfa\xed\xfe",
+        b"\xcf\xfa\xed\xfe",
         b"OTTO",
         b"RIFF",
         b"ID3",
@@ -179,24 +182,13 @@ fn has_known_binary_magic(bytes: &[u8]) -> bool {
     if PREFIXES.iter().any(|prefix| bytes.starts_with(prefix)) {
         return true;
     }
-    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
-        return true;
-    }
-    if bytes.starts_with(&[0x00, 0x01, 0x00, 0x00]) {
-        return true;
-    }
-    if bytes.len() > 262 && bytes.get(257..262) == Some(b"ustar") {
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) || bytes.starts_with(&[0x00, 0x01, 0x00, 0x00]) {
         return true;
     }
 
-    matches!(
-        bytes.get(..4),
-        Some([0xfe, 0xed, 0xfa, 0xce]
-            | [0xfe, 0xed, 0xfa, 0xcf]
-            | [0xce, 0xfa, 0xed, 0xfe]
-            | [0xcf, 0xfa, 0xed, 0xfe]
-            | [0xca, 0xfe, 0xba, 0xbe])
-    )
+    bytes
+        .get(257..262)
+        .is_some_and(|magic| magic == b"ustar")
 }
 
 #[cfg(test)]

--- a/src/bin/check_repo/output.rs
+++ b/src/bin/check_repo/output.rs
@@ -1,0 +1,301 @@
+// Copyright 2026 Jean-Claude Joanna
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OutputFormat {
+    Text,
+    Json,
+    GitHub,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum CliAction {
+    Run(OutputFormat),
+    Help,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Finding {
+    pub(crate) path: Option<String>,
+    pub(crate) line: Option<usize>,
+    pub(crate) message: String,
+}
+
+pub(crate) fn parse_cli() -> Result<CliAction, String> {
+    parse_args(env::args().skip(1), default_output_format())
+}
+
+pub(crate) fn help_text() -> &'static str {
+    "Usage: check_repo [--format text|json|github]\n\nFormats:\n  text    Human-readable output\n  json    Deterministic machine-readable findings\n  github  GitHub Actions workflow command annotations\n"
+}
+
+pub(crate) fn findings_from_raw(raw: impl IntoIterator<Item = String>) -> Vec<Finding> {
+    raw.into_iter().map(|value| Finding::from_raw(&value)).collect()
+}
+
+pub(crate) fn render(format: OutputFormat, findings: &[Finding]) {
+    match format {
+        OutputFormat::Text => render_text(findings),
+        OutputFormat::Json => render_json(findings),
+        OutputFormat::GitHub => render_github(findings),
+    }
+}
+
+impl Finding {
+    fn from_raw(raw: &str) -> Self {
+        if let Some((path, line, message)) = split_path_line(raw) {
+            return Self {
+                path: Some(path.to_owned()),
+                line: Some(line),
+                message: message.to_owned(),
+            };
+        }
+
+        if let Some((prefix, message)) = raw.split_once(':')
+            && looks_like_path(prefix)
+        {
+            return Self {
+                path: Some(prefix.to_owned()),
+                line: None,
+                message: message.trim_start().to_owned(),
+            };
+        }
+
+        if let Some((prefix, _)) = raw.split_once(' ')
+            && looks_like_path(prefix)
+        {
+            return Self {
+                path: Some(prefix.to_owned()),
+                line: None,
+                message: raw[prefix.len()..].trim_start().to_owned(),
+            };
+        }
+
+        Self {
+            path: None,
+            line: None,
+            message: raw.to_owned(),
+        }
+    }
+}
+
+fn parse_args<I>(args: I, default: OutputFormat) -> Result<CliAction, String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut args = args.into_iter();
+    let Some(first) = args.next() else {
+        return Ok(CliAction::Run(default));
+    };
+
+    if matches!(first.as_str(), "-h" | "--help") {
+        if args.next().is_some() {
+            return Err("--help does not accept additional arguments".to_owned());
+        }
+        return Ok(CliAction::Help);
+    }
+
+    if first != "--format" {
+        return Err(format!("unknown argument: {first}"));
+    }
+
+    let value = args
+        .next()
+        .ok_or_else(|| "--format requires text, json, or github".to_owned())?;
+    if args.next().is_some() {
+        return Err("only one --format value may be supplied".to_owned());
+    }
+
+    let format = match value.as_str() {
+        "text" => OutputFormat::Text,
+        "json" => OutputFormat::Json,
+        "github" => OutputFormat::GitHub,
+        _ => return Err(format!("unsupported output format: {value}")),
+    };
+    Ok(CliAction::Run(format))
+}
+
+fn default_output_format() -> OutputFormat {
+    if env::var_os("GITHUB_ACTIONS").is_some_and(|value| value == "true") {
+        OutputFormat::GitHub
+    } else {
+        OutputFormat::Text
+    }
+}
+
+fn split_path_line(raw: &str) -> Option<(&str, usize, &str)> {
+    let (path, rest) = raw.split_once(':')?;
+    if !looks_like_path(path) {
+        return None;
+    }
+
+    let digit_count = rest
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_count == 0 {
+        return None;
+    }
+
+    let line = rest[..digit_count].parse().ok()?;
+    let message = rest[digit_count..]
+        .strip_prefix(':')
+        .unwrap_or(&rest[digit_count..])
+        .trim_start();
+    Some((path, line, message))
+}
+
+fn looks_like_path(value: &str) -> bool {
+    !value.is_empty()
+        && !value.chars().any(char::is_whitespace)
+        && (value.contains('/') || value.contains('.') || value.starts_with('.'))
+}
+
+fn render_text(findings: &[Finding]) {
+    if findings.is_empty() {
+        println!("Repository check passed.");
+        return;
+    }
+
+    println!("Repository check failed:");
+    for finding in findings {
+        match (&finding.path, finding.line) {
+            (Some(path), Some(line)) => println!("- {path}:{line} {}", finding.message),
+            (Some(path), None) => println!("- {path}: {}", finding.message),
+            (None, _) => println!("- {}", finding.message),
+        }
+    }
+}
+
+fn render_json(findings: &[Finding]) {
+    print!("{{\"ok\":{},\"findings\":[", findings.is_empty());
+    for (index, finding) in findings.iter().enumerate() {
+        if index > 0 {
+            print!(",");
+        }
+        print!("{{\"path\":");
+        match &finding.path {
+            Some(path) => print!("\"{}\"", json_escape(path)),
+            None => print!("null"),
+        }
+        print!(",\"line\":");
+        match finding.line {
+            Some(line) => print!("{line}"),
+            None => print!("null"),
+        }
+        print!(",\"message\":\"{}\"}}", json_escape(&finding.message));
+    }
+    println!("]}}");
+}
+
+fn render_github(findings: &[Finding]) {
+    if findings.is_empty() {
+        println!("::notice::Repository check passed.");
+        return;
+    }
+
+    for finding in findings {
+        let message = github_message_escape(&finding.message);
+        match (&finding.path, finding.line) {
+            (Some(path), Some(line)) => println!(
+                "::error file={},line={}::{message}",
+                github_property_escape(path),
+                line
+            ),
+            (Some(path), None) => println!(
+                "::error file={}::{message}",
+                github_property_escape(path)
+            ),
+            (None, _) => println!("::error::{message}"),
+        }
+    }
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            character if character < ' ' => {
+                use std::fmt::Write as _;
+                let _ = write!(escaped, "\\u{:04x}", u32::from(character));
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+fn github_message_escape(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+fn github_property_escape(value: &str) -> String {
+    github_message_escape(value)
+        .replace(':', "%3A")
+        .replace(',', "%2C")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliAction, Finding, OutputFormat, json_escape, parse_args};
+
+    #[test]
+    fn parses_supported_output_formats() {
+        assert_eq!(
+            parse_args(["--format".to_owned(), "json".to_owned()], OutputFormat::Text),
+            Ok(CliAction::Run(OutputFormat::Json))
+        );
+        assert_eq!(
+            parse_args(Vec::<String>::new(), OutputFormat::GitHub),
+            Ok(CliAction::Run(OutputFormat::GitHub))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_cli_arguments() {
+        assert!(parse_args(["--wat".to_owned()], OutputFormat::Text).is_err());
+        assert!(
+            parse_args(
+                ["--format".to_owned(), "xml".to_owned()],
+                OutputFormat::Text
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn extracts_structured_path_and_line() {
+        assert_eq!(
+            Finding::from_raw("src/main.rs:12 unsafe construct"),
+            Finding {
+                path: Some("src/main.rs".to_owned()),
+                line: Some(12),
+                message: "unsafe construct".to_owned(),
+            }
+        );
+        assert_eq!(
+            Finding::from_raw("README.md: required file is missing"),
+            Finding {
+                path: Some("README.md".to_owned()),
+                line: None,
+                message: "required file is missing".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn escapes_json_control_characters() {
+        assert_eq!(json_escape("a\"b\\c\n"), "a\\\"b\\\\c\\n");
+    }
+}

--- a/src/bin/check_repo/output.rs
+++ b/src/bin/check_repo/output.rs
@@ -208,7 +208,7 @@ fn render_github(findings: &[Finding]) {
                 line
             ),
             (Some(path), None) => {
-                println!("::error file={}::{message}", github_property_escape(path))
+                println!("::error file={}::{message}", github_property_escape(path));
             }
             (None, _) => println!("::error::{message}"),
         }

--- a/src/bin/check_repo/output.rs
+++ b/src/bin/check_repo/output.rs
@@ -32,7 +32,9 @@ pub(crate) fn help_text() -> &'static str {
 }
 
 pub(crate) fn findings_from_raw(raw: impl IntoIterator<Item = String>) -> Vec<Finding> {
-    raw.into_iter().map(|value| Finding::from_raw(&value)).collect()
+    raw.into_iter()
+        .map(|value| Finding::from_raw(&value))
+        .collect()
 }
 
 pub(crate) fn render(format: OutputFormat, findings: &[Finding]) {
@@ -205,10 +207,9 @@ fn render_github(findings: &[Finding]) {
                 github_property_escape(path),
                 line
             ),
-            (Some(path), None) => println!(
-                "::error file={}::{message}",
-                github_property_escape(path)
-            ),
+            (Some(path), None) => {
+                println!("::error file={}::{message}", github_property_escape(path))
+            }
             (None, _) => println!("::error::{message}"),
         }
     }
@@ -253,7 +254,10 @@ mod tests {
     #[test]
     fn parses_supported_output_formats() {
         assert_eq!(
-            parse_args(["--format".to_owned(), "json".to_owned()], OutputFormat::Text),
+            parse_args(
+                ["--format".to_owned(), "json".to_owned()],
+                OutputFormat::Text
+            ),
             Ok(CliAction::Run(OutputFormat::Json))
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- Split bounded content classification and diagnostic rendering into focused Rust modules.
- Add deterministic text, JSON, and GitHub Actions annotation output without introducing runtime dependencies.
- Parse stable path, line, and message fields from repository findings.
- Select GitHub annotation output automatically inside Actions while preserving text output locally.
- Add explicit `--format text`, `--format json`, `--format github`, and `--help` handling with strict argument validation.
- Keep content inspection fail-closed for misleading binary extensions, undeclared binary data, invalid UTF-8, and oversized text.
- Update the roadmap and operational documentation so structured diagnostics are a completed repository capability rather than future work.

## Verification

- Protected `Repository smoke test` required before merge.
- The gate runs formatting, compilation, strict Clippy, tests, documentation, and the repository doctor under Rust 1.97.1.

## Risk / Notes

- No runtime dependency, external service, write permission, or production integration is added.
- Existing repository-policy exit behavior remains fail-closed.
- JSON and GitHub workflow-command escaping are covered by unit tests.